### PR TITLE
Leak MockServers to fix tests on Windows

### DIFF
--- a/crates/agentgateway/src/mcp/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/openapi/tests.rs
@@ -16,8 +16,8 @@ use crate::types::agent::Target;
 use crate::{ProxyInputs, client, mcp};
 
 // Helper to create a handler and mock server for tests
-async fn setup() -> (MockServer, Handler) {
-	let server = MockServer::start().await;
+async fn setup() -> (&'static MockServer, Handler) {
+	let server = Box::leak(Box::new(MockServer::start().await));
 	let host = server.uri();
 	let parsed = reqwest::Url::parse(&host).unwrap();
 	let config = crate::config::parse_config("{}".to_string(), None).unwrap();

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -504,9 +504,15 @@ async fn convert(client: client::Client, i: LocalConfig) -> anyhow::Result<Norma
 			all_backends.extend_from_slice(&backends);
 			ls.insert(l)
 		}
+		let sockaddr = if cfg!(target_family = "unix") {
+			SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), b.port)
+		} else {
+			// Windows and IPv6 don't mix well apparently?
+			SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), b.port)
+		};
 		let b = Bind {
 			key: bind_name,
-			address: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), b.port),
+			address: sockaddr,
 			listeners: ls,
 		};
 		all_binds.push(b)

--- a/crates/agentgateway/tests/integration.rs
+++ b/crates/agentgateway/tests/integration.rs
@@ -34,8 +34,6 @@ async fn test_basic_proxy_comparison() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-// TODO: why does this fail on windows?
-#[cfg(target_family = "unix")]
 async fn test_basic_routes() -> anyhow::Result<()> {
 	let mock = wiremock::MockServer::start().await;
 	Mock::given(wiremock::matchers::path_regex("/.*"))

--- a/crates/core/src/readiness.rs
+++ b/crates/core/src/readiness.rs
@@ -56,8 +56,8 @@ impl Drop for BlockReady {
 			);
 		} else {
 			info!(
-				"Task '{}' complete ({dur:?}), still awaiting {left} tasks",
-				self.name
+				"Task '{}' complete ({dur:?}), still awaiting {left} tasks: {pending:?}",
+				self.name,
 			);
 		}
 	}


### PR DESCRIPTION
I think we're running into
https://github.com/LukeMathWalker/wiremock-rs/issues/156, so explicitly leak mockserver resources to avoid port sharing