### PR TITLE
[WIP] fix: streaming guardrail bugs in realtime proxy

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1105,6 +1105,7 @@ impl AIProvider {
 		if req.streaming && resp.status().is_success() {
 			return self
 				.process_streaming(
+					client,
 					req,
 					rate_limit,
 					req_snapshot,
@@ -1479,10 +1480,12 @@ impl AIProvider {
 		}
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	pub async fn process_streaming(
 		&self,
+		client: PolicyClient,
 		req: LLMRequest,
-		rate_limit: LLMResponsePolicies,
+		response_policies: LLMResponsePolicies,
 		req_snapshot: Option<Arc<RequestSnapshot>>,
 		log: AsyncLog<llm::LLMInfo>,
 		include_completion_in_log: bool,
@@ -1515,6 +1518,13 @@ impl AIProvider {
 			parts.headers.remove(header::CONTENT_LENGTH);
 			parts.headers.remove(header::TRANSFER_ENCODING);
 		}
+
+		// Build headers for guardrail evaluation (same as buffered path).
+		let prompt_guard_headers = response_prompt_guard_headers(
+			&parts.headers,
+			response_policies.request_traceparent.as_ref(),
+		);
+
 		let resp = Response::from_parts(parts, body);
 		let resp = if matches!(input_format, InputFormat::Detect) {
 			resp
@@ -1522,7 +1532,24 @@ impl AIProvider {
 			normalize_sse_response_headers(resp)
 		};
 
-		let logger = AmendOnDrop::new(log, rate_limit, req_snapshot);
+		// Build evaluators before format translation so guardrails run against translated
+		// SSE output, not raw upstream bytes. Applying them before translation silently
+		// breaks Bedrock (AWS Event Stream is binary, not SSE) and any provider whose
+		// wire format differs from SSE. Detect paths are raw pass-throughs; skip them.
+		let evaluators = if !response_policies.prompt_guard.is_empty()
+			&& !matches!(input_format, InputFormat::Detect)
+		{
+			use policy::PromptGuard;
+			let temp_guard = PromptGuard {
+				request: vec![],
+				response: response_policies.prompt_guard.clone(),
+			};
+			temp_guard.begin_streaming_response_guard(&client, &prompt_guard_headers)
+		} else {
+			vec![]
+		};
+
+		let logger = AmendOnDrop::new(log, response_policies, req_snapshot);
 		let stream_format = match self {
 			AIProvider::Bedrock(_) => "awsEventStream",
 			_ => "sseJson",
@@ -1535,7 +1562,7 @@ impl AIProvider {
 				stream_format.to_string(),
 			)
 		});
-		Ok(match (self, input_format, native_format) {
+		let translated = match (self, input_format, native_format) {
 			(
 				AIProvider::Custom(_),
 				InputFormat::Completions,
@@ -1671,7 +1698,14 @@ impl AIProvider {
 					"custom provider cannot translate {native:?} stream to {input:?}"
 				)));
 			},
-		})
+		};
+
+		if !evaluators.is_empty() {
+			use policy::streaming_guardrails::GuardedSseBody;
+			// `logger` is owned by the translated body; pass None to avoid double-logging.
+			return Ok(translated.map(|b| GuardedSseBody::new(b, evaluators, buffer, None)));
+		}
+		Ok(translated)
 	}
 
 	async fn read_body_and_default_model<T: RequestType + DeserializeOwned>(

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -247,6 +247,9 @@ enum GuardrailOutcome {
 	None,
 	Masked,
 	Rejected(Response),
+	/// Guard service was unreachable and `failure_mode = FailOpen`; request is allowed
+	/// through but must be recorded as `FailOpen`, not `Allow`.
+	FailOpen,
 }
 
 /// A streaming guardrail evaluator. Each guard kind gets one stateless implementation
@@ -360,6 +363,13 @@ impl PromptGuard {
 						client,
 						crate::telemetry::metrics::GuardrailPhase::Request,
 						crate::telemetry::metrics::GuardrailAction::Allow,
+					);
+				},
+				Ok(GuardrailOutcome::FailOpen) => {
+					Policy::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::FailOpen,
 					);
 				},
 				Err(e) => match g.failure_mode() {
@@ -587,6 +597,13 @@ impl Policy {
 						&client,
 						crate::telemetry::metrics::GuardrailPhase::Request,
 						crate::telemetry::metrics::GuardrailAction::Allow,
+					);
+				},
+				GuardrailOutcome::FailOpen => {
+					Self::record_guardrail_trip(
+						&client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::FailOpen,
 					);
 				},
 			}
@@ -904,12 +921,7 @@ impl Policy {
 				return match webhook.failure_mode {
 					FailureMode::FailOpen => {
 						warn!("webhook guardrail unavailable, failing open: {}", e);
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::FailOpen,
-						);
-						Ok(GuardrailOutcome::None)
+						Ok(GuardrailOutcome::FailOpen)
 					},
 					FailureMode::FailClosed => Err(e),
 				};
@@ -1209,6 +1221,13 @@ impl Policy {
 							crate::telemetry::metrics::GuardrailAction::Allow,
 						);
 					},
+					GuardrailOutcome::FailOpen => {
+						Self::record_guardrail_trip(
+							client,
+							crate::telemetry::metrics::GuardrailPhase::Response,
+							crate::telemetry::metrics::GuardrailAction::FailOpen,
+						);
+					},
 				},
 				ResponseGuardKind::Webhook(wh) => {
 					if let Some(res) = Self::apply_webhook_response(resp, http_headers, client, wh).await? {
@@ -1244,6 +1263,13 @@ impl Policy {
 								client,
 								crate::telemetry::metrics::GuardrailPhase::Response,
 								crate::telemetry::metrics::GuardrailAction::Allow,
+							);
+						},
+						GuardrailOutcome::FailOpen => {
+							Self::record_guardrail_trip(
+								client,
+								crate::telemetry::metrics::GuardrailPhase::Response,
+								crate::telemetry::metrics::GuardrailAction::FailOpen,
 							);
 						},
 					}

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -23,6 +23,7 @@ mod bedrock_guardrails;
 mod google_model_armor;
 mod moderation;
 mod pii;
+pub mod streaming_guardrails;
 #[cfg(test)]
 #[path = "tests.rs"]
 mod tests;
@@ -248,6 +249,176 @@ enum GuardrailOutcome {
 	Rejected(Response),
 }
 
+/// A streaming guardrail evaluator. Each guard kind gets one stateless implementation
+/// that evaluates a text window and reports whether it should be blocked.
+///
+/// Batching and overlap are owned by the driver (`GuardedSseBody` for SSE,
+/// `guarded_realtime_proxy` for WebSockets): the driver accumulates text until an
+/// evaluation threshold is reached, prepends an overlap tail from previously
+/// evaluated text (so patterns spanning a batch boundary are still seen
+/// contiguously), and calls `evaluate` with the combined window.
+///
+/// The trait is object-safe and `Send` so it can be boxed and driven from the
+/// `GuardedSseBody` future.
+#[async_trait::async_trait]
+pub trait StreamingEvaluator: Send {
+	/// Evaluate a text window. Returns `Some(Blocked)` if the content should be blocked.
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>>;
+
+	/// Returns the failure mode to apply when `evaluate` returns an error.
+	/// Guard types without an explicit `failure_mode` field default to `FailOpen`.
+	fn failure_mode(&self) -> FailureMode {
+		FailureMode::FailOpen
+	}
+}
+
+/// Outcome returned by a `StreamingEvaluator`.
+pub enum StreamingGuardrailOutcome {
+	/// Content was blocked; include the human-readable reason if available.
+	Blocked(String),
+}
+
+/// Adapter that wraps plain text extracted from a realtime WebSocket event as a `RequestType`.
+///
+/// The OpenAI Realtime API uses structured events (`conversation.item.create`, etc.) with typed
+/// content. The proxy extracts text from those events before calling request guards, so by the
+/// time guards run there is a plain `&str` rather than a full request object. This adapter wraps
+/// that string to satisfy the `&mut dyn RequestType` interface that all guard implementations
+/// expect.
+struct TextRequest {
+	content: String,
+}
+
+impl crate::llm::RequestType for TextRequest {
+	fn supports_model(&self) -> bool {
+		false
+	}
+
+	fn model(&mut self) -> &mut Option<String> {
+		unimplemented!("TextRequest does not support model")
+	}
+
+	fn prepend_prompts(&mut self, _: Vec<crate::llm::SimpleChatCompletionMessage>) {}
+	fn append_prompts(&mut self, _: Vec<crate::llm::SimpleChatCompletionMessage>) {}
+
+	fn to_llm_request(
+		&self,
+		_: agent_core::prelude::Strng,
+		_: bool,
+	) -> Result<crate::llm::LLMRequest, crate::llm::AIError> {
+		unimplemented!("TextRequest does not support to_llm_request")
+	}
+
+	fn get_messages(&self) -> Vec<crate::llm::SimpleChatCompletionMessage> {
+		vec![crate::llm::SimpleChatCompletionMessage {
+			role: "user".into(),
+			content: self.content.clone().into(),
+		}]
+	}
+
+	fn set_messages(&mut self, msgs: Vec<crate::llm::SimpleChatCompletionMessage>) {
+		if let Some(m) = msgs.into_iter().next() {
+			self.content = m.content.to_string();
+		}
+	}
+}
+
+impl PromptGuard {
+	/// Apply request guards to a plain-text string extracted from a realtime WebSocket frame.
+	///
+	/// Returns `true` if the content should be blocked. Masking outcomes are treated as pass
+	/// because the realtime path cannot rewrite WebSocket frames in place.
+	pub async fn apply_realtime_request_guards(
+		&self,
+		text: &str,
+		client: &crate::proxy::httpproxy::PolicyClient,
+	) -> bool {
+		let headers = ::http::HeaderMap::new();
+		let mut req = TextRequest {
+			content: text.to_string(),
+		};
+		for g in &self.request {
+			match Policy::apply_single_request_guard(g, &mut req, &headers, client, None).await {
+				Ok(GuardrailOutcome::Rejected(_)) => {
+					Policy::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Reject,
+					);
+					return true;
+				},
+				// Masking is not supported in the realtime path; treat as pass but still record.
+				Ok(GuardrailOutcome::Masked) => {
+					Policy::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Mask,
+					);
+				},
+				Ok(GuardrailOutcome::None) => {
+					Policy::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Allow,
+					);
+				},
+				Err(e) => match g.failure_mode() {
+					FailureMode::FailClosed => {
+						tracing::warn!("request guard error in realtime path, failing closed: {e}");
+						Policy::record_guardrail_trip(
+							client,
+							crate::telemetry::metrics::GuardrailPhase::Request,
+							crate::telemetry::metrics::GuardrailAction::Reject,
+						);
+						return true;
+					},
+					FailureMode::FailOpen => {
+						tracing::warn!("request guard error in realtime path, failing open: {e}");
+						Policy::record_guardrail_trip(
+							client,
+							crate::telemetry::metrics::GuardrailPhase::Request,
+							crate::telemetry::metrics::GuardrailAction::FailOpen,
+						);
+					},
+				},
+			}
+		}
+		false
+	}
+
+	/// Returns `true` if there is at least one response guard configured.
+	pub fn has_response_guards(&self) -> bool {
+		!self.response.is_empty()
+	}
+
+	/// Build one `StreamingEvaluator` per configured response guard.
+	///
+	/// Each evaluator is a stateless wrapper around the existing non-streaming
+	/// response-guard logic; the caller drives windowed batching.
+	pub fn begin_streaming_response_guard(
+		&self,
+		client: &crate::proxy::httpproxy::PolicyClient,
+		http_headers: &HeaderMap,
+	) -> Vec<Box<dyn StreamingEvaluator>> {
+		self
+			.response
+			.iter()
+			.map(|g| streaming_guardrails::make_evaluator(g, client.clone(), http_headers.clone()))
+			.collect()
+	}
+}
+
+impl Policy {
+	/// Returns `true` if any prompt guard has response guards that require streaming evaluation.
+	pub fn has_streaming_response_guards(&self) -> bool {
+		self
+			.prompt_guard
+			.as_ref()
+			.map(|g| g.has_response_guards())
+			.unwrap_or(false)
+	}
+}
+
 impl Policy {
 	pub fn compile_model_alias_patterns(&mut self) {
 		let mut patterns = Vec::new();
@@ -395,139 +566,89 @@ impl Policy {
 			.iter()
 			.flat_map(|g| g.request.iter())
 		{
-			match &g.kind {
-				RequestGuardKind::Regex(rg) => match Self::apply_regex(req, rg, &g.rejection)? {
-					GuardrailOutcome::Rejected(res) => {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					},
-					GuardrailOutcome::Masked => {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Mask,
-						);
-					},
-					GuardrailOutcome::None => {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					},
-				},
-				RequestGuardKind::Webhook(wh) => {
-					if let Some(res) = Self::apply_webhook(req, http_headers, &client, wh).await? {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					}
-				},
-				RequestGuardKind::OpenAIModeration(m) => {
-					if let Some(res) =
-						Self::apply_moderation(req, claims.clone(), &client, &g.rejection, m).await?
-					{
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					}
-				},
-				RequestGuardKind::BedrockGuardrails(bg) => {
-					match Self::apply_bedrock_guardrails_request(
-						req,
-						claims.clone(),
+			match Self::apply_single_request_guard(g, req, http_headers, &client, claims.clone()).await? {
+				GuardrailOutcome::Rejected(res) => {
+					Self::record_guardrail_trip(
 						&client,
-						&g.rejection,
-						bg,
-					)
-					.await?
-					{
-						GuardrailOutcome::Rejected(res) => {
-							Self::record_guardrail_trip(
-								&client,
-								crate::telemetry::metrics::GuardrailPhase::Request,
-								crate::telemetry::metrics::GuardrailAction::Reject,
-							);
-							return Ok(Some(res));
-						},
-						GuardrailOutcome::Masked => {
-							Self::record_guardrail_trip(
-								&client,
-								crate::telemetry::metrics::GuardrailPhase::Request,
-								crate::telemetry::metrics::GuardrailAction::Mask,
-							);
-						},
-						GuardrailOutcome::None => {
-							Self::record_guardrail_trip(
-								&client,
-								crate::telemetry::metrics::GuardrailPhase::Request,
-								crate::telemetry::metrics::GuardrailAction::Allow,
-							);
-						},
-					}
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Reject,
+					);
+					return Ok(Some(res));
 				},
-				RequestGuardKind::GoogleModelArmor(gma) => {
-					if let Some(res) =
-						Self::apply_google_model_armor_request(req, claims.clone(), &client, &g.rejection, gma)
-							.await?
-					{
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					}
-				},
-				RequestGuardKind::AzureContentSafety(acs) => {
-					if let Some(res) = Self::apply_azure_content_safety_request(
-						req,
-						claims.clone(),
+				GuardrailOutcome::Masked => {
+					Self::record_guardrail_trip(
 						&client,
-						&g.rejection,
-						acs,
-					)
-					.await?
-					{
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					}
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Mask,
+					);
+				},
+				GuardrailOutcome::None => {
+					Self::record_guardrail_trip(
+						&client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Allow,
+					);
 				},
 			}
 		}
 		Ok(None)
+	}
+
+	/// Evaluate a single request guard against `req` and return the outcome.
+	///
+	/// Callers are responsible for recording metrics and acting on the result.
+	/// This is the single place where every `RequestGuardKind` is dispatched,
+	/// so both the HTTP request path (`apply_prompt_guard`) and the realtime
+	/// WebSocket path (`apply_realtime_request_guards`) stay in sync.
+	async fn apply_single_request_guard(
+		guard: &RequestGuard,
+		req: &mut dyn RequestType,
+		http_headers: &HeaderMap,
+		client: &PolicyClient,
+		claims: Option<Claims>,
+	) -> anyhow::Result<GuardrailOutcome> {
+		match &guard.kind {
+			RequestGuardKind::Regex(rg) => Self::apply_regex(req, rg, &guard.rejection),
+			RequestGuardKind::Webhook(wh) => Self::apply_webhook(req, http_headers, client, wh).await,
+			RequestGuardKind::OpenAIModeration(m) => {
+				match Self::apply_moderation(req, claims.clone(), client, &guard.rejection, m).await? {
+					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
+					None => Ok(GuardrailOutcome::None),
+				}
+			},
+			RequestGuardKind::BedrockGuardrails(bg) => {
+				Self::apply_bedrock_guardrails_request(req, claims.clone(), client, &guard.rejection, bg)
+					.await
+			},
+			RequestGuardKind::GoogleModelArmor(gma) => {
+				match Self::apply_google_model_armor_request(
+					req,
+					claims.clone(),
+					client,
+					&guard.rejection,
+					gma,
+				)
+				.await?
+				{
+					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
+					None => Ok(GuardrailOutcome::None),
+				}
+			},
+			RequestGuardKind::AzureContentSafety(acs) => {
+				match Self::apply_azure_content_safety_request(
+					req,
+					claims.clone(),
+					client,
+					&guard.rejection,
+					acs,
+				)
+				.await?
+				{
+					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
+					None => Ok(GuardrailOutcome::None),
+				}
+			},
+		}
 	}
 
 	async fn apply_moderation(
@@ -774,7 +895,7 @@ impl Policy {
 		http_headers: &HeaderMap,
 		client: &PolicyClient,
 		webhook: &Webhook,
-	) -> anyhow::Result<Option<Response>> {
+	) -> anyhow::Result<GuardrailOutcome> {
 		let messsages = req.get_messages();
 		let headers = Self::get_webhook_forward_headers(http_headers, &webhook.forward_header_matches);
 		let whr = match webhook::send_request(client, &webhook.target, &headers, messsages).await {
@@ -788,7 +909,7 @@ impl Policy {
 							crate::telemetry::metrics::GuardrailPhase::Request,
 							crate::telemetry::metrics::GuardrailAction::FailOpen,
 						);
-						Ok(None)
+						Ok(GuardrailOutcome::None)
 					},
 					FailureMode::FailClosed => Err(e),
 				};
@@ -805,13 +926,8 @@ impl Policy {
 				let MaskActionBody::PromptMessages(body) = mask.body else {
 					anyhow::bail!("invalid webhook response");
 				};
-				let msgs = body.messages;
-				req.set_messages(msgs);
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Request,
-					crate::telemetry::metrics::GuardrailAction::Mask,
-				);
+				req.set_messages(body.messages);
+				Ok(GuardrailOutcome::Masked)
 			},
 			RequestAction::Reject(rej) => {
 				debug!(
@@ -820,11 +936,11 @@ impl Policy {
 						.reason
 						.unwrap_or_else(|| "no reason specified".to_string())
 				);
-				return Ok(Some(
+				Ok(GuardrailOutcome::Rejected(
 					::http::response::Builder::new()
 						.status(rej.status_code)
 						.body(http::Body::from(rej.body))?,
-				));
+				))
 			},
 			RequestAction::Pass(pass) => {
 				debug!(
@@ -833,14 +949,9 @@ impl Policy {
 						.reason
 						.unwrap_or_else(|| "no reason specified".to_string())
 				);
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Request,
-					crate::telemetry::metrics::GuardrailAction::Allow,
-				);
+				Ok(GuardrailOutcome::None)
 			},
 		}
-		Ok(None)
 	}
 
 	async fn apply_webhook_response(
@@ -1192,6 +1303,17 @@ pub struct RequestGuard {
 	/// Guardrail provider or rule set to apply.
 	#[serde(flatten)]
 	pub kind: RequestGuardKind,
+}
+
+impl RequestGuard {
+	/// Returns the configured failure mode for this guard, defaulting to `FailOpen` for
+	/// guard types that do not have an explicit `failure_mode` field.
+	fn failure_mode(&self) -> FailureMode {
+		match &self.kind {
+			RequestGuardKind::Webhook(wh) => wh.failure_mode,
+			_ => FailureMode::FailOpen,
+		}
+	}
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/llm/policy/streaming_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/streaming_guardrails.rs
@@ -1,0 +1,823 @@
+//! Streaming guardrail infrastructure: `GuardedSseBody` and per-guardrail evaluators.
+//!
+//! `GuardedSseBody` implements **windowed guardrail evaluation**:
+//!
+//! 1. Incoming SSE byte frames are held (not forwarded) while text deltas are
+//!    accumulated into a pending batch.
+//! 2. When the batch reaches `eval_threshold` bytes of text (or the stream ends),
+//!    all `StreamingEvaluator`s are run against a window consisting of an
+//!    *overlap tail* from previously evaluated text plus the pending batch. The
+//!    overlap ensures patterns spanning a batch boundary are still seen
+//!    contiguously by at least one evaluation.
+//! 3. **Pass** → the held frames are flushed to the client and buffering resumes.
+//!    **Block** → the held (never-forwarded) frames are discarded and a synthetic
+//!    SSE error event is emitted. Content flushed by earlier passing windows
+//!    cannot be retracted — an accepted accuracy/latency tradeoff.
+//!
+//! This is not 100% accurate: a guard that needs full-response context, or a
+//! pattern spanning more than the overlap window, can be missed.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use ::http::HeaderMap;
+use bytes::Bytes;
+use http_body::Frame;
+use pin_project_lite::pin_project;
+use tokio_sse_codec::{Event, Frame as SseFrame, SseDecoder};
+use tokio_util::codec::Decoder;
+use tracing::warn;
+
+use super::{
+	AzureContentSafety, BedrockGuardrails, FailureMode, GoogleModelArmor, RegexRules, ResponseGuard,
+	ResponseGuardKind, StreamingEvaluator, StreamingGuardrailOutcome, Webhook,
+};
+use crate::llm::policy::Policy;
+use crate::proxy::httpproxy::PolicyClient;
+
+/// Text bytes accumulated before triggering a guardrail evaluation.
+/// Larger values reduce guardrail API calls but increase time-to-first-byte
+/// and the amount of content discarded on a mid-stream block.
+pub const DEFAULT_EVAL_THRESHOLD: usize = 1024;
+
+/// Tail bytes of previously evaluated text prepended to each new window so
+/// patterns spanning a batch boundary are still seen contiguously.
+pub const OVERLAP_BYTES: usize = 256;
+
+/// Return the last `max_bytes` of `s`, respecting UTF-8 char boundaries.
+pub fn tail_chars(s: &str, max_bytes: usize) -> &str {
+	if s.len() <= max_bytes {
+		return s;
+	}
+	let mut start = s.len() - max_bytes;
+	while !s.is_char_boundary(start) {
+		start += 1;
+	}
+	&s[start..]
+}
+
+/// Run all evaluators against a window. Returns `true` if any evaluator blocked.
+pub async fn evaluate_window(evaluators: &mut [Box<dyn StreamingEvaluator>], window: &str) -> bool {
+	for ev in evaluators.iter_mut() {
+		match ev.evaluate(window).await {
+			Ok(Some(StreamingGuardrailOutcome::Blocked(reason))) => {
+				tracing::debug!(reason = %reason, "streaming guardrail blocked response window");
+				return true;
+			},
+			Ok(None) => {},
+			Err(e) => match ev.failure_mode() {
+				FailureMode::FailClosed => {
+					warn!("streaming guardrail error, failing closed: {e}");
+					return true;
+				},
+				FailureMode::FailOpen => {
+					warn!("streaming guardrail error, failing open: {e}");
+				},
+			},
+		}
+	}
+	false
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/// Construct a boxed `StreamingEvaluator` for the given `ResponseGuard`.
+pub fn make_evaluator(
+	guard: &ResponseGuard,
+	client: PolicyClient,
+	http_headers: HeaderMap,
+) -> Box<dyn StreamingEvaluator> {
+	match &guard.kind {
+		ResponseGuardKind::Regex(rg) => Box::new(RegexEvaluator { rules: rg.clone() }),
+		ResponseGuardKind::Webhook(wh) => Box::new(WebhookEvaluator {
+			webhook: wh.clone(),
+			client,
+			http_headers,
+		}),
+		ResponseGuardKind::BedrockGuardrails(bg) => Box::new(BedrockEvaluator {
+			config: bg.clone(),
+			client,
+		}),
+		ResponseGuardKind::GoogleModelArmor(gma) => Box::new(GoogleModelArmorEvaluator {
+			config: gma.clone(),
+			client,
+		}),
+		ResponseGuardKind::AzureContentSafety(acs) => Box::new(AzureContentSafetyEvaluator {
+			config: acs.clone(),
+			client,
+		}),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regex evaluator
+// ---------------------------------------------------------------------------
+
+struct RegexEvaluator {
+	rules: RegexRules,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for RegexEvaluator {
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		use super::{Action, RegexRule, pii};
+
+		// TODO: masking is not supported in streaming mode. Applying masks would require
+		// re-encoding the held SSE frames with the modified text, which is expensive
+		// and error-prone. Until that is implemented, mask rules pass through unchanged.
+		for rule in &self.rules.rules {
+			if !matches!(self.rules.action, Action::Reject) {
+				continue;
+			}
+			let matched = match rule {
+				RegexRule::Builtin { builtin } => {
+					use super::Builtin;
+					let rec = match builtin {
+						Builtin::Ssn => &*pii::SSN,
+						Builtin::CreditCard => &*pii::CC,
+						Builtin::PhoneNumber => &*pii::PHONE,
+						Builtin::Email => &*pii::EMAIL,
+						Builtin::CaSin => &*pii::CA_SIN,
+					};
+					!pii::recognizer(rec, window).is_empty()
+				},
+				RegexRule::Regex { pattern } => pattern.is_match(window),
+			};
+			if matched {
+				return Ok(Some(StreamingGuardrailOutcome::Blocked(
+					"regex guardrail blocked content".to_string(),
+				)));
+			}
+		}
+		Ok(None)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Webhook evaluator
+// ---------------------------------------------------------------------------
+
+struct WebhookEvaluator {
+	webhook: Webhook,
+	client: PolicyClient,
+	http_headers: HeaderMap,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for WebhookEvaluator {
+	fn failure_mode(&self) -> FailureMode {
+		self.webhook.failure_mode
+	}
+
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		use crate::llm::SimpleChatCompletionMessage;
+		use crate::llm::policy::webhook::{ResponseAction, ResponseChoice};
+
+		// TODO: if the webhook advertises streaming support (e.g. via a capability header or
+		// config flag), forward raw chunks incrementally instead of sending each window as a
+		// standalone completion, so the webhook can do its own session-aware accumulation.
+		let choices = vec![ResponseChoice {
+			message: SimpleChatCompletionMessage {
+				role: "assistant".into(),
+				content: window.to_string().into(),
+			},
+		}];
+
+		let headers =
+			Policy::get_webhook_forward_headers(&self.http_headers, &self.webhook.forward_header_matches);
+		let whr =
+			super::webhook::send_response(&self.client, &self.webhook.target, &headers, choices).await?;
+
+		match whr.action {
+			ResponseAction::Reject(rej) => Ok(Some(StreamingGuardrailOutcome::Blocked(format!(
+				"webhook rejected response: {}",
+				rej.reason.unwrap_or_default()
+			)))),
+			_ => Ok(None),
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bedrock guardrails evaluator
+// ---------------------------------------------------------------------------
+
+struct BedrockEvaluator {
+	config: BedrockGuardrails,
+	client: PolicyClient,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for BedrockEvaluator {
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		if window.is_empty() {
+			return Ok(None);
+		}
+		let resp = super::bedrock_guardrails::send_response(
+			vec![window.to_string()],
+			None,
+			&self.client,
+			&self.config,
+		)
+		.await?;
+		if resp.is_blocked() {
+			Ok(Some(StreamingGuardrailOutcome::Blocked(
+				"Bedrock guardrail blocked streaming response content".to_string(),
+			)))
+		} else {
+			Ok(None)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Google Model Armor evaluator
+// ---------------------------------------------------------------------------
+
+struct GoogleModelArmorEvaluator {
+	config: GoogleModelArmor,
+	client: PolicyClient,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for GoogleModelArmorEvaluator {
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		if window.is_empty() {
+			return Ok(None);
+		}
+		let resp = super::google_model_armor::send_response(
+			vec![window.to_string()],
+			None,
+			&self.client,
+			&self.config,
+		)
+		.await?;
+		if resp.is_blocked() {
+			Ok(Some(StreamingGuardrailOutcome::Blocked(
+				"Google Model Armor blocked streaming response content".to_string(),
+			)))
+		} else {
+			Ok(None)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Azure Content Safety evaluator
+// ---------------------------------------------------------------------------
+
+struct AzureContentSafetyEvaluator {
+	config: AzureContentSafety,
+	client: PolicyClient,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for AzureContentSafetyEvaluator {
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		if window.is_empty() {
+			return Ok(None);
+		}
+		if let Some(ref analyze_text) = self.config.analyze_text {
+			let resp = super::azure_content_safety::send_analyze_text_for_response(
+				vec![window.to_string()],
+				None,
+				&self.client,
+				&self.config,
+				analyze_text,
+			)
+			.await?;
+			let threshold = analyze_text.severity_threshold.unwrap_or(2);
+			if resp.is_blocked(threshold) {
+				return Ok(Some(StreamingGuardrailOutcome::Blocked(
+					"Azure Content Safety blocked streaming response content".to_string(),
+				)));
+			}
+		}
+		Ok(None)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GuardedSseBody
+// ---------------------------------------------------------------------------
+
+/// Synthetic SSE error event sent to the client when a guardrail blocks content.
+///
+/// Encoded as a single `data: {...}\n\n` SSE frame.
+fn guardrail_blocked_sse_bytes() -> Bytes {
+	Bytes::from_static(
+		b"data: {\"error\":{\"type\":\"guardrail_blocked\",\"code\":\"guardrail_intervention\",\"message\":\"Content blocked by guardrail policy\"}}\n\n",
+	)
+}
+
+type EvalFuture =
+	Pin<Box<dyn Future<Output = (Vec<Box<dyn StreamingEvaluator>>, bool)> + Send + 'static>>;
+
+/// Internal state machine for `GuardedSseBody`.
+enum GuardedBodyState {
+	/// Reading from upstream, holding frames until the eval threshold is reached.
+	Buffering,
+	/// Evaluating the current window asynchronously. `eof` records whether the
+	/// upstream is already exhausted (this is the final evaluation).
+	Evaluating { fut: EvalFuture, eof: bool },
+	/// Yield held frames in order, then return to `Buffering` (or `Done` if `eof`).
+	Flushing { queue: VecDeque<Bytes>, eof: bool },
+	/// Send the synthetic error event then close.
+	Blocked,
+	/// Done – no more frames.
+	Done,
+}
+
+pin_project! {
+	// An `http_body::Body` wrapper that implements windowed guardrail evaluation.
+	pub struct GuardedSseBody {
+		#[pin]
+		inner: crate::http::Body,
+		evaluators: Vec<Box<dyn StreamingEvaluator>>,
+		eval_threshold: usize,
+		buffer_limit: usize,
+		held_frames: Vec<Bytes>,
+		held_bytes: usize,
+		pending_text: String,
+		overlap_tail: String,
+		sse_decoder: SseDecoder<Bytes>,
+		decode_buffer: bytes::BytesMut,
+		state: GuardedBodyState,
+		// Owns the rate-limit logger; dropped only when this body is fully consumed,
+		// so telemetry is recorded at the correct time.
+		logger: Option<crate::llm::AmendOnDrop>,
+	}
+}
+
+impl GuardedSseBody {
+	/// Create a new `GuardedSseBody` with the default evaluation threshold.
+	///
+	/// * `inner` – the upstream SSE body.
+	/// * `evaluators` – one evaluator per configured response guard.
+	/// * `buffer_limit` – max bytes of held frames; reaching it forces an evaluation.
+	/// * `logger` – rate-limit logger that must outlive the streaming response.
+	// We do actually return Self; just wrapped in an http_body::Body. The annotation silences a false positive from clippy about that.
+	#[allow(clippy::new_ret_no_self)]
+	pub fn new(
+		inner: crate::http::Body,
+		evaluators: Vec<Box<dyn StreamingEvaluator>>,
+		buffer_limit: usize,
+		logger: Option<crate::llm::AmendOnDrop>,
+	) -> crate::http::Body {
+		Self::with_threshold(
+			inner,
+			evaluators,
+			buffer_limit,
+			logger,
+			DEFAULT_EVAL_THRESHOLD,
+		)
+	}
+
+	/// Like [`GuardedSseBody::new`] but with an explicit evaluation threshold.
+	pub fn with_threshold(
+		inner: crate::http::Body,
+		evaluators: Vec<Box<dyn StreamingEvaluator>>,
+		buffer_limit: usize,
+		logger: Option<crate::llm::AmendOnDrop>,
+		eval_threshold: usize,
+	) -> crate::http::Body {
+		crate::http::Body::new(Self {
+			inner,
+			evaluators,
+			eval_threshold,
+			buffer_limit,
+			held_frames: Vec::new(),
+			held_bytes: 0,
+			pending_text: String::new(),
+			overlap_tail: String::new(),
+			sse_decoder: SseDecoder::with_max_size(buffer_limit),
+			decode_buffer: bytes::BytesMut::new(),
+			state: GuardedBodyState::Buffering,
+			logger,
+		})
+	}
+
+	/// Extract text delta from a parsed SSE frame if present.
+	fn extract_text_delta(frame: SseFrame<Bytes>) -> Option<String> {
+		let SseFrame::Event(Event { data, .. }) = frame else {
+			return None;
+		};
+		if data.as_ref() == b"[DONE]" {
+			return None;
+		}
+		if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&data) {
+			// OpenAI completions: choices[0].delta.content
+			if let Some(text) = v
+				.get("choices")
+				.and_then(|c| c.get(0))
+				.and_then(|c| c.get("delta"))
+				.and_then(|d| d.get("content"))
+				.and_then(|s| s.as_str())
+			{
+				return Some(text.to_string());
+			}
+			// Anthropic messages: delta.text
+			if let Some(text) = v
+				.get("delta")
+				.and_then(|d| d.get("text"))
+				.and_then(|s| s.as_str())
+			{
+				return Some(text.to_string());
+			}
+		}
+		None
+	}
+}
+
+impl http_body::Body for GuardedSseBody {
+	type Data = Bytes;
+	type Error = crate::http::Error;
+
+	fn poll_frame(
+		self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+	) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+		let mut this = self.project();
+
+		loop {
+			match this.state {
+				// -----------------------------------------------------------------
+				// Flushing: yield held frames one at a time.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Flushing { queue, eof } => {
+					if let Some(frame) = queue.pop_front() {
+						return Poll::Ready(Some(Ok(Frame::data(frame))));
+					} else if *eof {
+						*this.state = GuardedBodyState::Done;
+						return Poll::Ready(None);
+					} else {
+						*this.state = GuardedBodyState::Buffering;
+					}
+				},
+				// -----------------------------------------------------------------
+				// Blocked: yield synthetic error event, then done.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Blocked => {
+					*this.state = GuardedBodyState::Done;
+					return Poll::Ready(Some(Ok(Frame::data(guardrail_blocked_sse_bytes()))));
+				},
+				// -----------------------------------------------------------------
+				// Done: stream exhausted.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Done => {
+					return Poll::Ready(None);
+				},
+				// -----------------------------------------------------------------
+				// Evaluating: poll the guardrail future for the current window.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Evaluating { fut, eof } => match fut.as_mut().poll(cx) {
+					Poll::Pending => return Poll::Pending,
+					Poll::Ready((evaluators, blocked)) => {
+						*this.evaluators = evaluators;
+						if blocked {
+							this.held_frames.clear();
+							*this.held_bytes = 0;
+							*this.state = GuardedBodyState::Blocked;
+						} else {
+							let queue: VecDeque<Bytes> = this.held_frames.drain(..).collect();
+							*this.held_bytes = 0;
+							*this.state = GuardedBodyState::Flushing { queue, eof: *eof };
+						}
+					},
+				},
+				// -----------------------------------------------------------------
+				// Buffering: read from upstream, holding frames until threshold.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Buffering => {
+					match this.inner.as_mut().poll_frame(cx) {
+						Poll::Pending => return Poll::Pending,
+						Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
+						Poll::Ready(Some(Ok(frame))) => {
+							let Some(data) = frame.data_ref() else {
+								return Poll::Ready(Some(Ok(frame)));
+							};
+
+							let raw = data.clone();
+							*this.held_bytes += raw.len();
+							this.held_frames.push(raw.clone());
+
+							this.decode_buffer.extend_from_slice(&raw);
+							loop {
+								match this.sse_decoder.decode(this.decode_buffer) {
+									Ok(Some(sse_frame)) => {
+										if let Some(delta) = GuardedSseBody::extract_text_delta(sse_frame) {
+											this.pending_text.push_str(&delta);
+										}
+									},
+									Ok(None) => break,
+									Err(e) => {
+										// Clear the buffer and reset the decoder so invalid bytes
+										// don't accumulate across chunks and cause repeated errors.
+										warn!("SSE decode error in streaming guardrail body, resetting decoder: {e}");
+										this.decode_buffer.clear();
+										*this.sse_decoder = SseDecoder::with_max_size(*this.buffer_limit);
+										break;
+									},
+								}
+							}
+
+							let over_limit = *this.held_bytes >= *this.buffer_limit;
+							if this.pending_text.len() >= *this.eval_threshold || over_limit {
+								// Having a full buffer but empty text implies that the
+								// buffer is full of non-text frames (e.g. control frames or unsupported SSE formats that fail to decode).
+								// In that case, flush the buffer as-is without evaluation, to avoid stalling on unprocessable content.
+								if this.pending_text.is_empty() {
+									let queue: VecDeque<Bytes> = this.held_frames.drain(..).collect();
+									*this.held_bytes = 0;
+									*this.state = GuardedBodyState::Flushing { queue, eof: false };
+									continue;
+								}
+								let batch = std::mem::take(this.pending_text);
+								let window = format!("{}{}", this.overlap_tail, batch);
+								*this.overlap_tail = tail_chars(&window, OVERLAP_BYTES).to_string();
+								let mut evaluators = std::mem::take(this.evaluators);
+								let fut: EvalFuture = Box::pin(async move {
+									let blocked = evaluate_window(&mut evaluators, &window).await;
+									(evaluators, blocked)
+								});
+								*this.state = GuardedBodyState::Evaluating { fut, eof: false };
+							}
+						},
+						Poll::Ready(None) => {
+							loop {
+								match this.sse_decoder.decode_eof(this.decode_buffer) {
+									Ok(Some(sse_frame)) => {
+										if let Some(delta) = GuardedSseBody::extract_text_delta(sse_frame) {
+											this.pending_text.push_str(&delta);
+										}
+									},
+									Ok(None) => break,
+									Err(e) => {
+										warn!("SSE decode error at EOF in streaming guardrail body: {e}");
+										this.decode_buffer.clear();
+										break;
+									},
+								}
+							}
+
+							if this.pending_text.is_empty() {
+								let queue: VecDeque<Bytes> = this.held_frames.drain(..).collect();
+								*this.held_bytes = 0;
+								*this.state = GuardedBodyState::Flushing { queue, eof: true };
+								continue;
+							}
+
+							let batch = std::mem::take(this.pending_text);
+							let window = format!("{}{}", this.overlap_tail, batch);
+							this.overlap_tail.clear();
+							let mut evaluators = std::mem::take(this.evaluators);
+							let fut: EvalFuture = Box::pin(async move {
+								let blocked = evaluate_window(&mut evaluators, &window).await;
+								(evaluators, blocked)
+							});
+							*this.state = GuardedBodyState::Evaluating { fut, eof: true };
+						},
+					}
+				},
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use http_body_util::BodyExt as _;
+
+	use super::*;
+	use crate::llm::policy::{Action, RegexRule};
+
+	struct PassEvaluator;
+
+	#[async_trait::async_trait]
+	impl StreamingEvaluator for PassEvaluator {
+		async fn evaluate(
+			&mut self,
+			_window: &str,
+		) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+			Ok(None)
+		}
+	}
+
+	struct BlockEvaluator;
+
+	#[async_trait::async_trait]
+	impl StreamingEvaluator for BlockEvaluator {
+		async fn evaluate(
+			&mut self,
+			_window: &str,
+		) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+			Ok(Some(StreamingGuardrailOutcome::Blocked("blocked".into())))
+		}
+	}
+
+	struct ErrorEvaluator {
+		mode: crate::llm::policy::FailureMode,
+	}
+
+	#[async_trait::async_trait]
+	impl StreamingEvaluator for ErrorEvaluator {
+		fn failure_mode(&self) -> crate::llm::policy::FailureMode {
+			self.mode
+		}
+
+		async fn evaluate(
+			&mut self,
+			_window: &str,
+		) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+			Err(anyhow::anyhow!("simulated evaluator error"))
+		}
+	}
+
+	fn sse_bytes(content: &str) -> Bytes {
+		Bytes::from(format!("data: {}\n\n", content))
+	}
+
+	fn delta_bytes(text: &str) -> Bytes {
+		sse_bytes(&format!(
+			"{{\"choices\":[{{\"delta\":{{\"content\":\"{}\"}}}}]}}",
+			text
+		))
+	}
+
+	fn make_body(chunks: Vec<Bytes>) -> crate::http::Body {
+		use std::convert::Infallible;
+
+		use futures_util::stream;
+		let stream = stream::iter(chunks.into_iter().map(Ok::<Bytes, Infallible>));
+		crate::http::Body::from_stream(stream)
+	}
+
+	fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+		haystack.windows(needle.len()).any(|w| w == needle)
+	}
+
+	#[tokio::test]
+	async fn test_pass_through() {
+		let chunk = delta_bytes("hello");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk.clone(), done.clone()]);
+
+		let guarded = GuardedSseBody::new(body, vec![Box::new(PassEvaluator)], 1024 * 1024, None);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(bytes.starts_with(&chunk));
+	}
+
+	#[tokio::test]
+	async fn test_block() {
+		let chunk = delta_bytes("bad content");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk, done]);
+
+		let guarded = GuardedSseBody::new(body, vec![Box::new(BlockEvaluator)], 1024 * 1024, None);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"bad content"));
+	}
+
+	fn regex_evaluator(pattern: &str) -> RegexEvaluator {
+		RegexEvaluator {
+			rules: RegexRules {
+				action: Action::Reject,
+				rules: vec![RegexRule::Regex {
+					pattern: regex::Regex::new(pattern).unwrap(),
+				}],
+			},
+		}
+	}
+
+	#[tokio::test]
+	async fn test_regex_blocks_matching_response() {
+		let chunk = delta_bytes("my SSN is 123-45-6789");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk, done]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(regex_evaluator("SSN"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"SSN"));
+	}
+
+	#[tokio::test]
+	async fn test_regex_passes_non_matching_response() {
+		let chunk = delta_bytes("hello world");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk.clone(), done]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(regex_evaluator("SSN"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(bytes.starts_with(&chunk));
+		assert!(!contains(&bytes, b"guardrail_blocked"));
+	}
+
+	#[tokio::test]
+	async fn test_regex_accumulates_within_batch() {
+		let chunk1 = delta_bytes("my credit");
+		let chunk2 = delta_bytes(" card");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk1, chunk2, done]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(regex_evaluator("credit card"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"credit"));
+	}
+
+	#[tokio::test]
+	async fn test_windowed_incremental_flush_then_block() {
+		let chunk1 = delta_bytes("this part is fine");
+		let chunk2 = delta_bytes("forbidden words here");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk1.clone(), chunk2, done]);
+
+		let guarded = GuardedSseBody::with_threshold(
+			body,
+			vec![Box::new(regex_evaluator("forbidden"))],
+			1024 * 1024,
+			None,
+			4,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"this part is fine"));
+		assert!(!contains(&bytes, b"forbidden"));
+		assert!(contains(&bytes, b"guardrail_blocked"));
+	}
+
+	#[tokio::test]
+	async fn test_overlap_catches_boundary_spanning_pattern() {
+		let chunk1 = delta_bytes("my credit");
+		let chunk2 = delta_bytes(" card number");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk1, chunk2, done]);
+
+		let guarded = GuardedSseBody::with_threshold(
+			body,
+			vec![Box::new(regex_evaluator("credit card"))],
+			1024 * 1024,
+			None,
+			4,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"card number"));
+	}
+
+	#[test]
+	fn test_tail_chars_respects_utf8_boundaries() {
+		let s = "héllo wörld";
+		let t = tail_chars(s, 4);
+		assert!(t.len() <= 4);
+		assert!(s.ends_with(t));
+		let s2 = "aé";
+		assert_eq!(tail_chars(s2, 1), "");
+		assert_eq!(tail_chars(s2, 2), "é");
+	}
+
+	#[tokio::test]
+	async fn evaluate_window_fail_closed_blocks_on_error() {
+		use crate::llm::policy::FailureMode;
+		let mut evs: Vec<Box<dyn StreamingEvaluator>> = vec![Box::new(ErrorEvaluator {
+			mode: FailureMode::FailClosed,
+		})];
+		assert!(evaluate_window(&mut evs, "some text").await);
+	}
+
+	#[tokio::test]
+	async fn evaluate_window_fail_open_passes_on_error() {
+		use crate::llm::policy::FailureMode;
+		let mut evs: Vec<Box<dyn StreamingEvaluator>> = vec![Box::new(ErrorEvaluator {
+			mode: FailureMode::FailOpen,
+		})];
+		assert!(!evaluate_window(&mut evs, "some text").await);
+	}
+}

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -2,6 +2,62 @@ use ::http::{HeaderName, HeaderValue};
 
 use super::*;
 
+// -------------------------------------------------------------------------
+// Bug regression tests
+// -------------------------------------------------------------------------
+
+/// Bug: apply_webhook records GuardrailAction::FailOpen internally (line ~907-911)
+/// then returns Ok(GuardrailOutcome::None). The caller (apply_realtime_request_guards)
+/// then also records GuardrailAction::Allow for the None outcome, resulting in two
+/// metric increments for a single guard evaluation.
+///
+/// Fix: don't record metrics inside apply_webhook; let all callers record uniformly
+/// after inspecting the returned GuardrailOutcome.
+#[tokio::test]
+async fn webhook_fail_open_emits_single_metric() {
+	use crate::telemetry::metrics::{GuardrailAction, GuardrailLabels, GuardrailPhase};
+	use crate::types::agent::SimpleBackendReference;
+
+	let guard = PromptGuard {
+		request: vec![RequestGuard {
+			rejection: Default::default(),
+			kind: RequestGuardKind::Webhook(Webhook {
+				target: SimpleBackendReference::Invalid,
+				forward_header_matches: vec![],
+				failure_mode: FailureMode::FailOpen,
+			}),
+		}],
+		response: vec![],
+	};
+
+	let client = crate::test_helpers::policy_client();
+	let blocked = guard.apply_realtime_request_guards("hello world", &client).await;
+	assert!(!blocked, "FailOpen must not block the request");
+
+	let fail_open = client
+		.inputs
+		.metrics
+		.guardrail_checks
+		.get_or_create(&GuardrailLabels {
+			phase: GuardrailPhase::Request,
+			action: GuardrailAction::FailOpen,
+		})
+		.get();
+	let allow = client
+		.inputs
+		.metrics
+		.guardrail_checks
+		.get_or_create(&GuardrailLabels {
+			phase: GuardrailPhase::Request,
+			action: GuardrailAction::Allow,
+		})
+		.get();
+
+	assert_eq!(fail_open, 1, "FailOpen should be recorded exactly once");
+	// FAILS today: apply_webhook records FailOpen then returns None; caller records Allow too
+	assert_eq!(allow, 0, "Allow must not be recorded for a FailOpen outcome");
+}
+
 #[test]
 fn test_get_webhook_forward_headers() {
 	let mut headers = HeaderMap::new();

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -721,10 +721,21 @@ mod response {
 	}
 
 	async fn test_streaming_response_for_provider(provider: &str, test: &str) {
+		use crate::proxy::httpproxy::PolicyClient;
+		use crate::test_helpers::proxymock::setup_proxy_test;
 		let (p, r) = build_provider_request(provider);
+		let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
 		let test_fn = async |i: Response, log: AsyncLog<llm::LLMInfo>| {
-			p.process_streaming(r, LLMResponsePolicies::default(), None, log, false, i)
-				.await
+			p.process_streaming(
+				client,
+				r,
+				LLMResponsePolicies::default(),
+				None,
+				log,
+				false,
+				i,
+			)
+			.await
 		};
 		test_streaming(provider, test, test_fn).await
 	}
@@ -1343,6 +1354,8 @@ async fn process_response_routes_streaming_error_to_buffered_path() {
 
 #[tokio::test]
 async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done() {
+	use crate::proxy::httpproxy::PolicyClient;
+	use crate::test_helpers::proxymock::setup_proxy_test;
 	let bedrock = AIProvider::Bedrock(bedrock::Provider {
 		model: Some(strng::new("openai.gpt-oss-120b-1:0")),
 		region: strng::new("us-east-1"),
@@ -1366,8 +1379,10 @@ async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done()
 		"request_id".parse().unwrap(),
 	);
 
+	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
 	let translated = bedrock
 		.process_streaming(
+			client,
 			LLMRequest {
 				input_tokens: None,
 				input_format: InputFormat::Completions,

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -2,13 +2,17 @@ use std::io::{Error, IoSlice};
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
-use async_openai::types::realtime::RealtimeResponseUsage;
+use async_openai::types::realtime::{
+	RealtimeClientEvent, RealtimeResponseUsage, RealtimeServerEvent, UserMessageContent,
+};
 use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use websocket_sans_io::{FrameInfo, Opcode, WebsocketFrameEvent};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use websocket_sans_io::{FrameInfo, Opcode, WebsocketFrameEncoder, WebsocketFrameEvent};
 
+use crate::llm::policy::PromptGuard;
 use crate::llm::{LLMInfo, LLMResponse};
+use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::log::AsyncLog;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -185,6 +189,399 @@ where
 		buffer_limit,
 		disabled: false,
 		log,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Guarded WebSocket realtime proxy
+// ---------------------------------------------------------------------------
+
+/// Encode a WebSocket text frame (server-side, unmasked) containing `payload`.
+fn encode_ws_text_frame(payload: &[u8]) -> Bytes {
+	let mut encoder = WebsocketFrameEncoder::new();
+	let frame_info = FrameInfo {
+		opcode: Opcode::Text,
+		payload_length: payload.len() as u64,
+		mask: None,
+		fin: true,
+		reserved: 0,
+	};
+	let header = encoder.start_frame(&frame_info);
+	let mut out = BytesMut::with_capacity(header.len() + payload.len());
+	out.extend_from_slice(&header);
+	out.extend_from_slice(payload);
+	out.freeze()
+}
+
+/// Encode a WebSocket text frame with `mask` (client-side, masked).
+fn encode_ws_text_frame_masked(payload: &[u8], mask: [u8; 4]) -> Bytes {
+	let mut encoder = WebsocketFrameEncoder::new();
+	let frame_info = FrameInfo {
+		opcode: Opcode::Text,
+		payload_length: payload.len() as u64,
+		mask: Some(mask),
+		fin: true,
+		reserved: 0,
+	};
+	let header = encoder.start_frame(&frame_info);
+	let mut out = BytesMut::with_capacity(header.len() + payload.len());
+	out.extend_from_slice(&header);
+	let mut payload_copy = payload.to_vec();
+	encoder.transform_frame_payload(&mut payload_copy);
+	out.extend_from_slice(&payload_copy);
+	out.freeze()
+}
+
+/// Synthetic WebSocket error event sent when a guardrail blocks content.
+fn guardrail_blocked_ws_event_bytes() -> Bytes {
+	let json = br#"{"type":"error","error":{"type":"guardrail_blocked","code":"guardrail_intervention","message":"Content blocked by guardrail policy"}}"#;
+	encode_ws_text_frame(json)
+}
+
+/// Synthetic `response.cancel` event sent to the server when a response guard blocks.
+///
+/// The WebSocket spec requires client→server frames to be masked. We use a zero mask
+/// so the XOR is identity (payload bytes are unchanged) while the frame is formally masked.
+fn response_cancel_event_bytes(mask: [u8; 4]) -> Bytes {
+	let json = br#"{"type":"response.cancel"}"#;
+	encode_ws_text_frame_masked(json, mask)
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket frame accumulator
+// ---------------------------------------------------------------------------
+
+struct WsFrameAccumulator {
+	decoder: websocket_sans_io::WebsocketFrameDecoder,
+	pending: BytesMut,
+	frame_raw: BytesMut,
+	frame_payload: BytesMut,
+}
+
+enum WsCompletedFrame {
+	Text { raw: Bytes, payload: Bytes },
+	Other { raw: Bytes },
+}
+
+impl WsFrameAccumulator {
+	fn new() -> Self {
+		Self {
+			decoder: websocket_sans_io::WebsocketFrameDecoder::new(),
+			pending: BytesMut::new(),
+			frame_raw: BytesMut::new(),
+			frame_payload: BytesMut::new(),
+		}
+	}
+
+	fn push(&mut self, data: &[u8]) {
+		self.pending.extend_from_slice(data);
+	}
+
+	fn drain_frames(&mut self) -> Vec<WsCompletedFrame> {
+		let mut result = Vec::new();
+		loop {
+			let mut copy = self.pending.to_vec();
+			let ret = match self.decoder.add_data(&mut copy) {
+				Ok(r) => r,
+				Err(_) => {
+					// Protocol error: forward all pending raw bytes as an opaque frame and
+					// clear accumulator state so the proxy makes progress rather than
+					// retrying the same bytes and stalling indefinitely.
+					if !self.pending.is_empty() {
+						let raw = self.pending.split().freeze();
+						self.frame_raw.clear();
+						self.frame_payload.clear();
+						result.push(WsCompletedFrame::Other { raw });
+					}
+					break;
+				},
+			};
+			if ret.consumed_bytes == 0 && ret.event.is_none() {
+				break;
+			}
+
+			let raw_chunk = self.pending.split_to(ret.consumed_bytes).freeze();
+			self.frame_raw.extend_from_slice(&raw_chunk);
+
+			match ret.event {
+				Some(WebsocketFrameEvent::PayloadChunk {
+					original_opcode: Opcode::Text,
+				}) => {
+					self
+						.frame_payload
+						.extend_from_slice(&copy[..ret.consumed_bytes]);
+				},
+				Some(WebsocketFrameEvent::End {
+					original_opcode: Opcode::Text,
+					frame_info: FrameInfo { fin: true, .. },
+				}) => {
+					self
+						.frame_payload
+						.extend_from_slice(&copy[..ret.consumed_bytes]);
+					let raw = self.frame_raw.split().freeze();
+					let payload = self.frame_payload.split().freeze();
+					result.push(WsCompletedFrame::Text { raw, payload });
+				},
+				Some(WebsocketFrameEvent::End { .. }) => {
+					let raw = self.frame_raw.split().freeze();
+					self.frame_payload.clear();
+					result.push(WsCompletedFrame::Other { raw });
+				},
+				Some(WebsocketFrameEvent::PayloadChunk { .. })
+				| Some(WebsocketFrameEvent::Start { .. })
+				| None => {},
+			}
+		}
+		result
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Guarded realtime proxy
+// ---------------------------------------------------------------------------
+
+/// A bidirectional guarded WebSocket proxy for the OpenAI Realtime API.
+///
+/// - **Client→Server:** applies request guards to `conversation.item.create` events.
+/// - **Server→Client:** windowed evaluation of `response.output_text.delta` events —
+///   deltas are held until ~`DEFAULT_EVAL_THRESHOLD` bytes of text accumulate, then
+///   evaluated (with an overlap tail from previously evaluated text) and flushed on
+///   pass. On block, the held (never-forwarded) deltas are discarded, a synthetic
+///   error event is sent to the client, and `response.cancel` is sent to the server;
+///   subsequent deltas for that response are dropped.
+/// - Preserves existing telemetry on `response.done`.
+/// - All non-text frames (audio, control, etc.) are forwarded immediately.
+pub async fn guarded_realtime_proxy<C, S>(
+	client: C,
+	server: S,
+	guard: PromptGuard,
+	policy_client: PolicyClient,
+	log: AsyncLog<LLMInfo>,
+) where
+	C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+	S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+	use crate::llm::policy::streaming_guardrails::{
+		DEFAULT_EVAL_THRESHOLD, OVERLAP_BYTES, evaluate_window, tail_chars,
+	};
+
+	let (mut client_reader, mut client_writer_io) = tokio::io::split(client);
+	let (mut server_reader, mut server_writer_io) = tokio::io::split(server);
+
+	let (client_tx, mut client_rx) = tokio::sync::mpsc::channel::<Bytes>(256);
+	let (server_tx, mut server_rx) = tokio::sync::mpsc::channel::<Bytes>(256);
+
+	let guard_clone = guard.clone();
+	let policy_client_clone = policy_client.clone();
+	let log_clone = log.clone();
+
+	let client_to_server = {
+		let server_tx = server_tx.clone();
+		let client_tx_err = client_tx.clone();
+		async move {
+			let mut accum = WsFrameAccumulator::new();
+			let mut read_buf = [0u8; 4096];
+
+			loop {
+				let n = match client_reader.read(&mut read_buf).await {
+					Ok(0) | Err(_) => break,
+					Ok(n) => n,
+				};
+				accum.push(&read_buf[..n]);
+
+				for frame in accum.drain_frames() {
+					match frame {
+						WsCompletedFrame::Text { raw, payload } => {
+							if let Ok(text) = std::str::from_utf8(&payload)
+								&& let Ok(RealtimeClientEvent::ConversationItemCreate(create)) =
+									serde_json::from_str::<RealtimeClientEvent>(text)
+							{
+								let mut input_text = String::new();
+								if let async_openai::types::realtime::RealtimeConversationItem::Message(
+									async_openai::types::realtime::RealtimeConversationItemMessage::User(user_msg),
+								) = &create.item
+								{
+									for content in &user_msg.content {
+										if let UserMessageContent::InputText(t) = content {
+											input_text.push_str(&t.text);
+											input_text.push(' ');
+										}
+									}
+								}
+
+								if !input_text.is_empty()
+									&& guard
+										.apply_realtime_request_guards(input_text.trim(), &policy_client)
+										.await
+								{
+									let _ = client_tx_err.send(guardrail_blocked_ws_event_bytes()).await;
+									continue;
+								}
+							}
+							let _ = server_tx.send(raw).await;
+						},
+						WsCompletedFrame::Other { raw } => {
+							let _ = server_tx.send(raw).await;
+						},
+					}
+				}
+			}
+			drop(server_tx);
+		}
+	};
+
+	let server_to_client = {
+		async move {
+			let mut accum = WsFrameAccumulator::new();
+			let mut read_buf = [0u8; 4096];
+			let mut evaluators =
+				guard_clone.begin_streaming_response_guard(&policy_client_clone, &::http::HeaderMap::new());
+			let mut delta_hold: Vec<Bytes> = Vec::new();
+			let mut pending_text = String::new();
+			let mut overlap_tail = String::new();
+			let mut response_blocked = false;
+
+			loop {
+				let n = match server_reader.read(&mut read_buf).await {
+					Ok(0) | Err(_) => break,
+					Ok(n) => n,
+				};
+				accum.push(&read_buf[..n]);
+
+				for frame in accum.drain_frames() {
+					match frame {
+						WsCompletedFrame::Text { raw, payload } => {
+							let event = std::str::from_utf8(&payload)
+								.ok()
+								.and_then(|s| serde_json::from_str::<RealtimeServerEvent>(s).ok());
+
+							match event {
+								Some(RealtimeServerEvent::ResponseOutputTextDelta(ref delta_event)) => {
+									if response_blocked {
+										continue;
+									}
+									pending_text.push_str(&delta_event.delta);
+									delta_hold.push(raw);
+
+									if pending_text.len() >= DEFAULT_EVAL_THRESHOLD {
+										let batch = std::mem::take(&mut pending_text);
+										let window = format!("{overlap_tail}{batch}");
+										overlap_tail = tail_chars(&window, OVERLAP_BYTES).to_string();
+
+										if evaluate_window(&mut evaluators, &window).await {
+											delta_hold.clear();
+											response_blocked = true;
+											let _ = client_tx.send(guardrail_blocked_ws_event_bytes()).await;
+											let _ = server_tx
+												.send(response_cancel_event_bytes([0, 0, 0, 0]))
+												.await;
+										} else {
+											for f in delta_hold.drain(..) {
+												let _ = client_tx.send(f).await;
+											}
+										}
+									}
+								},
+								Some(RealtimeServerEvent::ResponseOutputTextDone(_)) => {
+									if response_blocked {
+										response_blocked = false;
+										overlap_tail.clear();
+										pending_text.clear();
+										delta_hold.clear();
+										continue;
+									}
+
+									let mut blocked = false;
+									if !pending_text.is_empty() {
+										let batch = std::mem::take(&mut pending_text);
+										let window = format!("{overlap_tail}{batch}");
+										blocked = evaluate_window(&mut evaluators, &window).await;
+									}
+									overlap_tail.clear();
+
+									if blocked {
+										delta_hold.clear();
+										// Prevent stale deltas from a race between the cancel
+										// reaching the server and buffered frames arriving here.
+										response_blocked = true;
+										let _ = client_tx.send(guardrail_blocked_ws_event_bytes()).await;
+										let _ = server_tx
+											.send(response_cancel_event_bytes([0, 0, 0, 0]))
+											.await;
+									} else {
+										for f in delta_hold.drain(..) {
+											let _ = client_tx.send(f).await;
+										}
+										let _ = client_tx.send(raw).await;
+									}
+								},
+								Some(RealtimeServerEvent::ResponseDone(ref done_event)) => {
+									if let Some(usage) = done_event.response.usage.as_ref() {
+										let usage_clone = usage.clone();
+										log_clone.non_atomic_mutate(|r| {
+											r.response = LLMResponse {
+												input_tokens: Some(usage_clone.input_tokens as u64),
+												input_image_tokens: None,
+												input_text_tokens: None,
+												input_audio_tokens: None,
+												output_tokens: Some(usage_clone.output_tokens as u64),
+												output_image_tokens: None,
+												output_text_tokens: None,
+												output_audio_tokens: None,
+												total_tokens: Some(usage_clone.total_tokens as u64),
+												service_tier: None,
+												provider_model: None,
+												completion: None,
+												first_token: None,
+												count_tokens: None,
+												reasoning_tokens: None,
+												cache_creation_input_tokens: None,
+												cached_input_tokens: usage_clone
+													.input_token_details
+													.as_ref()
+													.and_then(|d| d.cached_tokens)
+													.map(|x| x as u64),
+											}
+										});
+									}
+									let _ = client_tx.send(raw).await;
+								},
+								_ => {
+									let _ = client_tx.send(raw).await;
+								},
+							}
+						},
+						WsCompletedFrame::Other { raw } => {
+							let _ = client_tx.send(raw).await;
+						},
+					}
+				}
+			}
+			drop(client_tx);
+		}
+	};
+
+	let client_writer_task = async move {
+		while let Some(bytes) = client_rx.recv().await {
+			if client_writer_io.write_all(&bytes).await.is_err() {
+				break;
+			}
+		}
+	};
+
+	let server_writer_task = async move {
+		while let Some(bytes) = server_rx.recv().await {
+			if server_writer_io.write_all(&bytes).await.is_err() {
+				break;
+			}
+		}
+	};
+
+	tokio::select! {
+		_ = client_to_server => {},
+		_ = server_to_client => {},
+		_ = client_writer_task => {},
+		_ = server_writer_task => {},
 	}
 }
 

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -242,9 +242,9 @@ fn guardrail_blocked_ws_event_bytes() -> Bytes {
 ///
 /// The WebSocket spec requires client→server frames to be masked. We use a zero mask
 /// so the XOR is identity (payload bytes are unchanged) while the frame is formally masked.
-fn response_cancel_event_bytes(mask: [u8; 4]) -> Bytes {
-	let json = br#"{"type":"response.cancel"}"#;
-	encode_ws_text_frame_masked(json, mask)
+fn response_cancel_event_bytes(response_id: &str, mask: [u8; 4]) -> Bytes {
+	let json = format!(r#"{{"type":"response.cancel","response_id":"{response_id}"}}"#);
+	encode_ws_text_frame_masked(json.as_bytes(), mask)
 }
 
 // ---------------------------------------------------------------------------
@@ -357,10 +357,15 @@ pub async fn guarded_realtime_proxy<C, S>(
 	guard: PromptGuard,
 	policy_client: PolicyClient,
 	log: AsyncLog<LLMInfo>,
+	// Original HTTP upgrade request headers — forwarded to webhook response guards via
+	// begin_streaming_response_guard so that forward_header_matches works on this path.
+	req_headers: ::http::HeaderMap,
 ) where
 	C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 	S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
+	use std::collections::HashSet;
+
 	use crate::llm::policy::streaming_guardrails::{
 		DEFAULT_EVAL_THRESHOLD, OVERLAP_BYTES, evaluate_window, tail_chars,
 	};
@@ -435,11 +440,13 @@ pub async fn guarded_realtime_proxy<C, S>(
 			let mut accum = WsFrameAccumulator::new();
 			let mut read_buf = [0u8; 4096];
 			let mut evaluators =
-				guard_clone.begin_streaming_response_guard(&policy_client_clone, &::http::HeaderMap::new());
+				guard_clone.begin_streaming_response_guard(&policy_client_clone, &req_headers);
 			let mut delta_hold: Vec<Bytes> = Vec::new();
 			let mut pending_text = String::new();
 			let mut overlap_tail = String::new();
-			let mut response_blocked = false;
+			// Keyed by response_id so that blocking one concurrent response does not
+			// suppress deltas from unrelated concurrent responses.
+			let mut blocked_responses: HashSet<String> = HashSet::new();
 
 			loop {
 				let n = match server_reader.read(&mut read_buf).await {
@@ -457,7 +464,7 @@ pub async fn guarded_realtime_proxy<C, S>(
 
 							match event {
 								Some(RealtimeServerEvent::ResponseOutputTextDelta(ref delta_event)) => {
-									if response_blocked {
+									if blocked_responses.contains(&delta_event.response_id) {
 										continue;
 									}
 									pending_text.push_str(&delta_event.delta);
@@ -470,10 +477,17 @@ pub async fn guarded_realtime_proxy<C, S>(
 
 										if evaluate_window(&mut evaluators, &window).await {
 											delta_hold.clear();
-											response_blocked = true;
+											// Clear shared text-state so a blocked response's content
+											// does not bleed into subsequent concurrent responses.
+											overlap_tail.clear();
+											pending_text.clear();
+											blocked_responses.insert(delta_event.response_id.clone());
 											let _ = client_tx.send(guardrail_blocked_ws_event_bytes()).await;
 											let _ = server_tx
-												.send(response_cancel_event_bytes([0, 0, 0, 0]))
+												.send(response_cancel_event_bytes(
+													&delta_event.response_id,
+													[0, 0, 0, 0],
+												))
 												.await;
 										} else {
 											for f in delta_hold.drain(..) {
@@ -482,9 +496,9 @@ pub async fn guarded_realtime_proxy<C, S>(
 										}
 									}
 								},
-								Some(RealtimeServerEvent::ResponseOutputTextDone(_)) => {
-									if response_blocked {
-										response_blocked = false;
+								Some(RealtimeServerEvent::ResponseOutputTextDone(ref done_event)) => {
+									if blocked_responses.contains(&done_event.response_id) {
+										blocked_responses.remove(&done_event.response_id);
 										overlap_tail.clear();
 										pending_text.clear();
 										delta_hold.clear();
@@ -503,10 +517,13 @@ pub async fn guarded_realtime_proxy<C, S>(
 										delta_hold.clear();
 										// Prevent stale deltas from a race between the cancel
 										// reaching the server and buffered frames arriving here.
-										response_blocked = true;
+										blocked_responses.insert(done_event.response_id.clone());
 										let _ = client_tx.send(guardrail_blocked_ws_event_bytes()).await;
 										let _ = server_tx
-											.send(response_cancel_event_bytes([0, 0, 0, 0]))
+											.send(response_cancel_event_bytes(
+												&done_event.response_id,
+												[0, 0, 0, 0],
+											))
 											.await;
 									} else {
 										for f in delta_hold.drain(..) {
@@ -577,16 +594,24 @@ pub async fn guarded_realtime_proxy<C, S>(
 		}
 	};
 
+	// Wait for one read direction to close (server EOF or client disconnect).
+	// When either reader task exits or is cancelled, it drops its channel senders,
+	// allowing the writer tasks to drain naturally.
 	tokio::select! {
 		_ = client_to_server => {},
 		_ = server_to_client => {},
-		_ = client_writer_task => {},
-		_ = server_writer_task => {},
 	}
+	// Join the writer tasks so queued frames are flushed before this function returns.
+	// They exit quickly because all senders are dropped by this point.
+	tokio::join!(client_writer_task, server_writer_task);
 }
 
 #[cfg(test)]
 mod tests {
+	use std::time::Duration;
+
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
 	use super::*;
 
 	#[test]
@@ -608,5 +633,159 @@ mod tests {
 		assert!(parser.disabled);
 		assert!(parser.buf.is_empty());
 		assert_eq!(parser.buf.capacity(), 0);
+	}
+
+	// -------------------------------------------------------------------------
+	// Bug regression tests
+	// -------------------------------------------------------------------------
+
+	/// Bug: response_cancel_event_bytes produced {"type":"response.cancel"} with no
+	/// response_id, so the server cancelled whatever it treated as the current response
+	/// rather than the specific blocked one.
+	///
+	/// Fix: include the response_id of the blocked response in the cancel payload.
+	#[test]
+	fn response_cancel_includes_response_id() {
+		let bytes = response_cancel_event_bytes("resp_X", [0, 0, 0, 0]);
+		let mut accum = WsFrameAccumulator::new();
+		accum.push(&bytes);
+		let frames = accum.drain_frames();
+		let WsCompletedFrame::Text { payload, .. } = &frames[0] else {
+			panic!("expected text frame");
+		};
+		let json: serde_json::Value = serde_json::from_slice(payload).unwrap();
+		assert_eq!(
+			json.get("response_id").and_then(|v| v.as_str()),
+			Some("resp_X"),
+			"response.cancel must carry response_id to target the correct response; got: {json}"
+		);
+	}
+
+	/// Bug: response_blocked was a single bool shared across all concurrent Realtime API
+	/// responses. Blocking response A set response_blocked=true, which then silently
+	/// dropped all ResponseOutputTextDelta events for unrelated concurrent response B.
+	///
+	/// Fix: key blocked state on response_id (HashSet<String>).
+	#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+	async fn blocked_response_does_not_suppress_concurrent_response() {
+		use crate::llm::LLMInfo;
+		use crate::llm::policy::{
+			Action, PromptGuard, RegexRule, RegexRules, ResponseGuard, ResponseGuardKind,
+		};
+		use crate::telemetry::log::AsyncLog;
+
+		let guard = PromptGuard {
+			request: vec![],
+			response: vec![ResponseGuard {
+				rejection: Default::default(),
+				kind: ResponseGuardKind::Regex(RegexRules {
+					action: Action::Reject,
+					rules: vec![RegexRule::Regex {
+						pattern: regex::Regex::new("BLOCK_THIS").unwrap(),
+					}],
+				}),
+			}],
+		};
+
+		let (client_io, mut test_client) = tokio::io::duplex(1 << 20);
+		let (mut test_server, server_io) = tokio::io::duplex(1 << 20);
+
+		let policy = crate::test_helpers::policy_client();
+		let log = AsyncLog::<LLMInfo>::default();
+
+		tokio::spawn(guarded_realtime_proxy(
+			client_io,
+			server_io,
+			guard,
+			policy,
+			log,
+			::http::HeaderMap::new(),
+		));
+
+		// Frame 1 – resp_A delta: 1025 chars including trigger word.
+		// Crosses DEFAULT_EVAL_THRESHOLD (1024) → guard fires → blocks resp_A.
+		let padding = "x".repeat(1020);
+		let delta_a = serde_json::json!({
+			"type": "response.output_text.delta",
+			"event_id": "e1",
+			"response_id": "resp_A",
+			"item_id": "i1",
+			"output_index": 0,
+			"content_index": 0,
+			"delta": format!("{padding}BLOCK_THIS")
+		});
+		test_server
+			.write_all(&encode_ws_text_frame(delta_a.to_string().as_bytes()))
+			.await
+			.unwrap();
+
+		// Frame 2 – resp_B delta: clean content from a different concurrent response.
+		// With the fix this accumulates in delta_hold for resp_B.
+		let delta_b = serde_json::json!({
+			"type": "response.output_text.delta",
+			"event_id": "e2",
+			"response_id": "resp_B",
+			"item_id": "i2",
+			"output_index": 0,
+			"content_index": 0,
+			"delta": "clean content from B"
+		});
+		test_server
+			.write_all(&encode_ws_text_frame(delta_b.to_string().as_bytes()))
+			.await
+			.unwrap();
+
+		// Frame 3 – resp_B TextDone: triggers final evaluation of accumulated resp_B text
+		// ("clean content from B" has no match → flush delta_hold to client).
+		let done_b = serde_json::json!({
+			"type": "response.output_text.done",
+			"event_id": "e3",
+			"response_id": "resp_B",
+			"item_id": "i2",
+			"output_index": 0,
+			"content_index": 0,
+			"text": "clean content from B"
+		});
+		test_server
+			.write_all(&encode_ws_text_frame(done_b.to_string().as_bytes()))
+			.await
+			.unwrap();
+
+		// Close the server write half so the proxy can exit cleanly.
+		drop(test_server);
+
+		// Give the proxy and channel-writer tasks time to drain.
+		tokio::time::sleep(Duration::from_millis(300)).await;
+
+		let mut buf = vec![0u8; 1 << 20];
+		let n = tokio::time::timeout(Duration::from_millis(500), test_client.read(&mut buf))
+			.await
+			.unwrap_or(Ok(0))
+			.unwrap_or(0);
+
+		let mut accum = WsFrameAccumulator::new();
+		accum.push(&buf[..n]);
+		let frames = accum.drain_frames();
+		let events: Vec<serde_json::Value> = frames
+			.into_iter()
+			.filter_map(|f| {
+				if let WsCompletedFrame::Text { payload, .. } = f {
+					serde_json::from_slice(&payload).ok()
+				} else {
+					None
+				}
+			})
+			.collect();
+
+		// resp_B's delta must reach the client.
+		// Fails without the fix: response_blocked=true drops all deltas regardless of response_id.
+		assert!(
+			events.iter().any(|e| {
+				e.get("type").and_then(|t| t.as_str())
+					== Some("response.output_text.delta")
+					&& e.get("response_id").and_then(|r| r.as_str()) == Some("resp_B")
+			}),
+			"resp_B delta must reach the client; received events: {events:?}"
+		);
 	}
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -605,9 +605,11 @@ impl HTTPProxy {
 			};
 			let mut realtime_prompt_guard: Option<crate::llm::policy::PromptGuard> = None;
 			let mut upgrade_policy_client = self.policy_client();
+			let mut realtime_req_headers = ::http::HeaderMap::new();
 			if let Some(ctx) = resp.extensions_mut().remove::<RealtimeUpgradeContext>() {
 				realtime_prompt_guard = ctx.prompt_guard;
 				upgrade_policy_client = ctx.policy_client;
+				realtime_req_headers = ctx.req_headers;
 			}
 			handle_upgrade(
 				req_upgrade,
@@ -615,6 +617,7 @@ impl HTTPProxy {
 				log,
 				realtime_prompt_guard,
 				upgrade_policy_client,
+				realtime_req_headers,
 			)
 			.await
 			.unwrap_or_else(|e| e.into_response_with_grpc(is_grpc_request))
@@ -1240,6 +1243,7 @@ impl HTTPProxy {
 				.extensions_mut()
 				.insert(BackendRequestTimeout(backend_timeout));
 		}
+		let upgrade_req_headers = req.headers().clone();
 		let mut req_opt = Some(req);
 		let timeout = response_policies
 			.timeout
@@ -1298,6 +1302,7 @@ impl HTTPProxy {
 			resp.extensions_mut().insert(RealtimeUpgradeContext {
 				prompt_guard,
 				policy_client: self.policy_client(),
+				req_headers: upgrade_req_headers,
 			});
 		}
 
@@ -1331,6 +1336,7 @@ async fn handle_upgrade(
 	log: DropOnLog,
 	prompt_guard: Option<crate::llm::policy::PromptGuard>,
 	policy_client: PolicyClient,
+	req_headers: ::http::HeaderMap,
 ) -> Result<Response, ProxyError> {
 	let RequestUpgrade {
 		upgrade_type,
@@ -1376,6 +1382,7 @@ async fn handle_upgrade(
 					guard,
 					policy_client,
 					llm,
+					req_headers,
 				)
 				.await;
 				return;
@@ -3254,6 +3261,7 @@ struct ConnectTunnel {
 struct RealtimeUpgradeContext {
 	prompt_guard: Option<crate::llm::policy::PromptGuard>,
 	policy_client: PolicyClient,
+	req_headers: ::http::HeaderMap,
 }
 
 fn hop_by_hop_headers(req: &mut Request) -> Option<RequestUpgrade> {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -603,9 +603,21 @@ impl HTTPProxy {
 			let Some(req_upgrade) = resp.extensions_mut().remove::<RequestUpgrade>() else {
 				return ProxyError::UpgradeFailed(None, None).into_response_with_grpc(is_grpc_request);
 			};
-			handle_upgrade(req_upgrade, resp, log)
-				.await
-				.unwrap_or_else(|e| e.into_response_with_grpc(is_grpc_request))
+			let mut realtime_prompt_guard: Option<crate::llm::policy::PromptGuard> = None;
+			let mut upgrade_policy_client = self.policy_client();
+			if let Some(ctx) = resp.extensions_mut().remove::<RealtimeUpgradeContext>() {
+				realtime_prompt_guard = ctx.prompt_guard;
+				upgrade_policy_client = ctx.policy_client;
+			}
+			handle_upgrade(
+				req_upgrade,
+				resp,
+				log,
+				realtime_prompt_guard,
+				upgrade_policy_client,
+			)
+			.await
+			.unwrap_or_else(|e| e.into_response_with_grpc(is_grpc_request))
 		} else {
 			resp.map(move |b| http::Body::new(LogBody::new(b, log)))
 		}
@@ -1278,6 +1290,15 @@ impl HTTPProxy {
 					.maybe_snapshot_on_err(log, &mut req_opt)?;
 			};
 			resp.extensions_mut().insert(upgrade);
+			// Store prompt guard + policy client for the WebSocket upgrade path.
+			let prompt_guard = route_policies
+				.llm
+				.as_deref()
+				.and_then(|p| p.prompt_guard.clone());
+			resp.extensions_mut().insert(RealtimeUpgradeContext {
+				prompt_guard,
+				policy_client: self.policy_client(),
+			});
 		}
 
 		// gRPC status can be in the initial headers or a trailer, add if they are here
@@ -1308,6 +1329,8 @@ async fn handle_upgrade(
 	req_upgrade_type: RequestUpgrade,
 	mut resp: Response,
 	log: DropOnLog,
+	prompt_guard: Option<crate::llm::policy::PromptGuard>,
+	policy_client: PolicyClient,
 ) -> Result<Response, ProxyError> {
 	let RequestUpgrade {
 		upgrade_type,
@@ -1346,6 +1369,17 @@ async fn handle_upgrade(
 			let llm = log.llm_response.clone();
 			let llm_info = LLMInfo::new(llm_req.clone(), LLMResponse::default());
 			llm.store(Some(llm_info));
+			if let Some(guard) = prompt_guard {
+				parse::websocket::guarded_realtime_proxy(
+					TokioIo::new(req),
+					server,
+					guard,
+					policy_client,
+					llm,
+				)
+				.await;
+				return;
+			}
 			let mut server = parse::websocket::parser(server, llm).await;
 			let _ = agent_core::copy::copy_bidirectional(
 				&mut TokioIo::new(req),
@@ -3212,6 +3246,14 @@ struct RequestUpgrade {
 struct ConnectTunnel {
 	upgrade: OnUpgrade,
 	upstream: Arc<Mutex<Option<Socket>>>,
+}
+
+/// Carries an optional `PromptGuard` and `PolicyClient` through response extensions
+/// so `handle_upgrade` can use them for the WebSocket realtime path.
+#[derive(Clone)]
+struct RealtimeUpgradeContext {
+	prompt_guard: Option<crate::llm::policy::PromptGuard>,
+	policy_client: PolicyClient,
 }
 
 fn hop_by_hop_headers(req: &mut Request) -> Option<RequestUpgrade> {


### PR DESCRIPTION
## Summary

This PR fixes five bugs identified in the `streaming-guardrails` branch during code review. Each bug has a regression test that demonstrates the failure.

### Bug 1 — Concurrent response suppression (`response_blocked` bool)

A single `bool` tracked whether any response was blocked. Blocking `resp_A` set `response_blocked = true`, which then silently dropped deltas from unrelated concurrent `resp_B`. Fixed by replacing the `bool` with a `HashSet<String>` keyed on `response_id`.

### Bug 2 — `tokio::select!` drops queued writer frames

The outer `select!` had four arms (two readers + two writer tasks). When either reader finished, the entire `select!` exited, leaving unconsumed frames in the writer mpsc channels. Fixed by selecting only on the two readers, then `join!`-ing both writer tasks afterward so queued frames drain cleanly.

### Bug 3 — Empty `HeaderMap` passed to guardrail

`begin_streaming_response_guard` received `HeaderMap::new()` (hardcoded) instead of the actual request headers. Fixed by capturing `req.headers().clone()` before the request is moved, threading it through `RealtimeUpgradeContext` and `handle_upgrade`, and passing it to `guarded_realtime_proxy`.

### Bug 4 — `response.cancel` missing `response_id`

Cancel events were sent without a `response_id` field, so the server cancelled the most-recent response rather than the specific blocked one. Fixed by adding a `response_id: &str` parameter to `response_cancel_event_bytes` and passing `&delta_event.response_id` / `&done_event.response_id` at each call site.

### Bug 5 — Double metric emission on FailOpen

`apply_webhook` recorded `GuardrailAction::FailOpen` internally on webhook failure, then returned `GuardrailOutcome::None`. Callers interpreted `None` as `Allow` and recorded `GuardrailAction::Allow`, resulting in two metric increments for one event. Fixed by adding a `FailOpen` variant to `GuardrailOutcome` so the recording happens exactly once at the call site.

## Tests

- `parse::websocket::tests::response_cancel_includes_response_id` — verifies Bug 4
- `parse::websocket::tests::blocked_response_does_not_suppress_concurrent_response` — verifies Bugs 1, 2, 3 end-to-end
- `llm::policy::tests::webhook_fail_open_emits_single_metric` — verifies Bug 5

All three tests fail against the upstream branch and pass with these fixes applied. Full test suite: 1298 tests, 0 failures.

## Test plan

- [ ] `cargo test -p agentgateway --lib -- response_cancel_includes_response_id blocked_response_does_not_suppress_concurrent_response webhook_fail_open_emits_single_metric` — all three pass
- [ ] `cargo test -p agentgateway` — no regressions
