### PR TITLE
fix: streaming guardrail bugs in realtime proxy

### DIFF
--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -248,6 +248,9 @@ enum GuardrailOutcome {
 	None,
 	Masked,
 	Rejected(Response),
+	/// Guard service was unreachable and `failure_mode = FailOpen`; request is allowed
+	/// through but must be recorded as `FailOpen`, not `Allow`.
+	FailOpen,
 }
 
 /// A streaming guardrail evaluator. Each guard kind gets one stateless implementation
@@ -402,6 +405,13 @@ impl PromptGuard {
 						crate::telemetry::metrics::GuardrailAction::Allow,
 					);
 				},
+				Ok(GuardrailOutcome::FailOpen) => {
+					Policy::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::FailOpen,
+					);
+				},
 				Err(e) => match g.failure_mode() {
 					FailureMode::FailClosed => {
 						tracing::warn!("request guard error in realtime path, failing closed: {e}");
@@ -472,6 +482,7 @@ impl PromptGuard {
 				Ok(None)
 			},
 			GuardrailOutcome::None => Ok(None),
+			GuardrailOutcome::FailOpen => Ok(None),
 		}
 	}
 }
@@ -655,6 +666,13 @@ impl Policy {
 						&client,
 						crate::telemetry::metrics::GuardrailPhase::Request,
 						crate::telemetry::metrics::GuardrailAction::Allow,
+					);
+				},
+				GuardrailOutcome::FailOpen => {
+					Self::record_guardrail_trip(
+						&client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::FailOpen,
 					);
 				},
 			}
@@ -972,12 +990,7 @@ impl Policy {
 				return match webhook.failure_mode {
 					FailureMode::FailOpen => {
 						warn!("webhook guardrail unavailable, failing open: {}", e);
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::FailOpen,
-						);
-						Ok(GuardrailOutcome::None)
+						Ok(GuardrailOutcome::FailOpen)
 					},
 					FailureMode::FailClosed => Err(e),
 				};
@@ -1027,7 +1040,7 @@ impl Policy {
 		http_headers: &HeaderMap,
 		client: &PolicyClient,
 		webhook: &Webhook,
-	) -> anyhow::Result<Option<Response>> {
+	) -> anyhow::Result<GuardrailOutcome> {
 		let messsages = resp.to_webhook_choices();
 		let headers = Self::get_webhook_forward_headers(http_headers, &webhook.forward_header_matches);
 		let whr = match webhook::send_response(client, &webhook.target, &headers, messsages).await {
@@ -1036,12 +1049,7 @@ impl Policy {
 				return match webhook.failure_mode {
 					FailureMode::FailOpen => {
 						warn!("webhook guardrail unavailable, failing open: {}", e);
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::FailOpen,
-						);
-						Ok(None)
+						Ok(GuardrailOutcome::FailOpen)
 					},
 					FailureMode::FailClosed => Err(e),
 				};
@@ -1060,11 +1068,7 @@ impl Policy {
 				};
 				let msgs = body.choices;
 				resp.set_webhook_choices(msgs)?;
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Response,
-					crate::telemetry::metrics::GuardrailAction::Mask,
-				);
+				Ok(GuardrailOutcome::Masked)
 			},
 			ResponseAction::Reject(rej) => {
 				debug!(
@@ -1073,16 +1077,11 @@ impl Policy {
 						.reason
 						.unwrap_or_else(|| "no reason specified".to_string())
 				);
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Response,
-					crate::telemetry::metrics::GuardrailAction::Reject,
-				);
-				return Ok(Some(
+				Ok(GuardrailOutcome::Rejected(
 					::http::response::Builder::new()
 						.status(rej.status_code)
 						.body(http::Body::from(rej.body))?,
-				));
+				))
 			},
 			ResponseAction::Pass(pass) => {
 				debug!(
@@ -1091,14 +1090,9 @@ impl Policy {
 						.reason
 						.unwrap_or_else(|| "no reason specified".to_string())
 				);
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Response,
-					crate::telemetry::metrics::GuardrailAction::Allow,
-				);
+				Ok(GuardrailOutcome::None)
 			},
 		}
-		Ok(None)
 	}
 
 	fn get_webhook_forward_headers(
@@ -1276,6 +1270,13 @@ impl Policy {
 						crate::telemetry::metrics::GuardrailAction::Allow,
 					);
 				},
+				GuardrailOutcome::FailOpen => {
+					Self::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Response,
+						crate::telemetry::metrics::GuardrailAction::FailOpen,
+					);
+				},
 			}
 		}
 		Ok(None)
@@ -1290,10 +1291,7 @@ impl Policy {
 		match &guard.kind {
 			ResponseGuardKind::Regex(rg) => Self::apply_regex_response(resp, rg, &guard.rejection),
 			ResponseGuardKind::Webhook(wh) => {
-				match Self::apply_webhook_response(resp, http_headers, client, wh).await? {
-					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
-					None => Ok(GuardrailOutcome::None),
-				}
+				Self::apply_webhook_response(resp, http_headers, client, wh).await
 			},
 			ResponseGuardKind::BedrockGuardrails(bg) => {
 				Self::apply_bedrock_guardrails_response(resp, None, client, &guard.rejection, bg).await

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -2,6 +2,53 @@ use ::http::{HeaderName, HeaderValue};
 
 use super::*;
 
+/// Regression test for Bug 5: `apply_webhook` previously recorded `GuardrailAction::FailOpen`
+/// internally and then returned `GuardrailOutcome::None`, causing callers to also record
+/// `GuardrailAction::Allow`. Only one metric should be emitted.
+#[tokio::test]
+async fn webhook_fail_open_emits_single_metric() {
+	use crate::telemetry::metrics::{GuardrailAction, GuardrailLabels, GuardrailPhase};
+	use crate::types::agent::SimpleBackendReference;
+
+	let guard = PromptGuard {
+		request: vec![RequestGuard {
+			rejection: Default::default(),
+			kind: RequestGuardKind::Webhook(Webhook {
+				target: SimpleBackendReference::Invalid,
+				forward_header_matches: vec![],
+				failure_mode: FailureMode::FailOpen,
+			}),
+		}],
+		response: vec![],
+	};
+
+	let client = crate::test_helpers::policy_client();
+	let blocked = guard.apply_realtime_request_guards("hello world", &client).await;
+	assert!(blocked.is_none(), "FailOpen must not block the request");
+
+	let fail_open = client
+		.inputs
+		.metrics
+		.guardrail_checks
+		.get_or_create(&GuardrailLabels {
+			phase: GuardrailPhase::Request,
+			action: GuardrailAction::FailOpen,
+		})
+		.get();
+	let allow = client
+		.inputs
+		.metrics
+		.guardrail_checks
+		.get_or_create(&GuardrailLabels {
+			phase: GuardrailPhase::Request,
+			action: GuardrailAction::Allow,
+		})
+		.get();
+
+	assert_eq!(fail_open, 1, "FailOpen should be recorded exactly once");
+	assert_eq!(allow, 0, "Allow must not be recorded for a FailOpen outcome");
+}
+
 #[test]
 fn test_get_webhook_forward_headers() {
 	let mut headers = HeaderMap::new();

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -2,7 +2,7 @@ use ::http::{HeaderName, HeaderValue};
 
 use super::*;
 
-/// Regression test for Bug 5: `apply_webhook` previously recorded `GuardrailAction::FailOpen`
+/// Regression test for: `apply_webhook` previously recorded `GuardrailAction::FailOpen`
 /// internally and then returned `GuardrailOutcome::None`, causing callers to also record
 /// `GuardrailAction::Allow`. Only one metric should be emitted.
 #[tokio::test]

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -2,9 +2,8 @@ use ::http::{HeaderName, HeaderValue};
 
 use super::*;
 
-/// Regression test for: `apply_webhook` previously recorded `GuardrailAction::FailOpen`
-/// internally and then returned `GuardrailOutcome::None`, causing callers to also record
-/// `GuardrailAction::Allow`. Only one metric should be emitted.
+/// When a webhook guard fails open, exactly one metric must be emitted (`FailOpen`); the caller
+/// must not additionally record `Allow`.
 #[tokio::test]
 async fn webhook_fail_open_emits_single_metric() {
 	use crate::telemetry::metrics::{GuardrailAction, GuardrailLabels, GuardrailPhase};

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -234,8 +234,12 @@ fn guardrail_blocked_ws_event_bytes(body: Bytes) -> Bytes {
 ///
 /// The WebSocket spec requires client→server frames to be masked. We use a zero mask
 /// so the XOR is identity (payload bytes are unchanged) while the frame is formally masked.
-fn response_cancel_event_bytes(response_id: &str, mask: [u8; 4]) -> Bytes {
-	let json = format!(r#"{{"type":"response.cancel","response_id":"{response_id}"}}"#);
+fn response_cancel_event_bytes(mask: [u8; 4]) -> Bytes {
+	// NOTE: response.cancel is sent without a response_id; the server cancels its most-recent
+	// active response. Correctly targeting a specific response in the Realtime API's out-of-band
+	// (concurrent) response pattern requires a response_id here and per-response blocked tracking
+	// — that is a known gap tracked in a follow-up issue.
+	let json = r#"{"type":"response.cancel"}"#;
 	encode_ws_text_frame_masked(json.as_bytes(), mask)
 }
 
@@ -434,9 +438,7 @@ pub async fn guarded_realtime_proxy<C, S>(
 			let mut delta_hold: Vec<Bytes> = Vec::new();
 			let mut pending_text = String::new();
 			let mut overlap_tail = String::new();
-			// Keyed by response_id so that blocking one concurrent response does not
-			// suppress deltas from unrelated concurrent responses.
-			let mut blocked_responses: std::collections::HashSet<String> = std::collections::HashSet::new();
+			let mut response_blocked = false;
 
 			loop {
 				let n = match server_reader.read(&mut read_buf).await {
@@ -454,7 +456,7 @@ pub async fn guarded_realtime_proxy<C, S>(
 
 							match event {
 								Some(RealtimeServerEvent::ResponseOutputTextDelta(ref delta_event)) => {
-									if blocked_responses.contains(&delta_event.response_id) {
+									if response_blocked {
 										continue;
 									}
 									pending_text.push_str(&delta_event.delta);
@@ -467,19 +469,16 @@ pub async fn guarded_realtime_proxy<C, S>(
 
 										if let Some(blocked_body) = evaluate_window(&mut evaluators, &window).await {
 											delta_hold.clear();
-											// Clear shared text-state so a blocked response's content
-											// does not bleed into subsequent concurrent responses.
+											// Clear text-state so a blocked response's content does not
+											// bleed into the next response's evaluation window.
 											overlap_tail.clear();
 											pending_text.clear();
-											blocked_responses.insert(delta_event.response_id.clone());
+											response_blocked = true;
 											let _ = client_tx
 												.send(guardrail_blocked_ws_event_bytes(blocked_body))
 												.await;
 											let _ = server_tx
-												.send(response_cancel_event_bytes(
-													&delta_event.response_id,
-													[0, 0, 0, 0],
-												))
+												.send(response_cancel_event_bytes([0, 0, 0, 0]))
 												.await;
 										} else {
 											for f in delta_hold.drain(..) {
@@ -488,9 +487,9 @@ pub async fn guarded_realtime_proxy<C, S>(
 										}
 									}
 								},
-								Some(RealtimeServerEvent::ResponseOutputTextDone(ref done_event)) => {
-									if blocked_responses.contains(&done_event.response_id) {
-										blocked_responses.remove(&done_event.response_id);
+								Some(RealtimeServerEvent::ResponseOutputTextDone(_)) => {
+									if response_blocked {
+										response_blocked = false;
 										overlap_tail.clear();
 										pending_text.clear();
 										delta_hold.clear();
@@ -507,17 +506,12 @@ pub async fn guarded_realtime_proxy<C, S>(
 
 									if let Some(blocked_body) = blocked_body {
 										delta_hold.clear();
-										// Prevent stale deltas from a race between the cancel
-										// reaching the server and buffered frames arriving here.
-										blocked_responses.insert(done_event.response_id.clone());
+										response_blocked = true;
 										let _ = client_tx
 											.send(guardrail_blocked_ws_event_bytes(blocked_body))
 											.await;
 										let _ = server_tx
-											.send(response_cancel_event_bytes(
-												&done_event.response_id,
-												[0, 0, 0, 0],
-											))
+											.send(response_cancel_event_bytes([0, 0, 0, 0]))
 											.await;
 									} else {
 										for f in delta_hold.drain(..) {
@@ -602,150 +596,6 @@ pub async fn guarded_realtime_proxy<C, S>(
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	/// `response.cancel` must include `response_id` so the server cancels the correct response
-	/// in a multi-response session.
-	#[test]
-	fn response_cancel_includes_response_id() {
-		let bytes = response_cancel_event_bytes("resp_X", [0, 0, 0, 0]);
-		let mut accum = WsFrameAccumulator::new();
-		accum.push(&bytes);
-		let frames = accum.drain_frames();
-		let WsCompletedFrame::Text { payload, .. } = &frames[0] else {
-			panic!("expected text frame");
-		};
-		// Unmask: zero mask is identity.
-		let json: serde_json::Value = serde_json::from_slice(payload).unwrap();
-		assert_eq!(
-			json.get("response_id").and_then(|v| v.as_str()),
-			Some("resp_X"),
-			"response.cancel must carry response_id; got: {json}"
-		);
-	}
-
-	/// Blocking one response must not suppress deltas from a concurrent response on the same
-	/// connection. Exercises per-response-id blocked tracking, writer-task drain ordering,
-	/// and correct header forwarding to the response guard.
-	#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-	async fn blocked_response_does_not_suppress_concurrent_response() {
-		use crate::llm::policy::{
-			Action, PromptGuard, RegexRule, RegexRules, RequestRejection, ResponseGuard, ResponseGuardKind,
-		};
-		use crate::proxy::httpproxy::PolicyClient;
-		use crate::telemetry::log::AsyncLog;
-
-		let guard = PromptGuard {
-			request: vec![],
-			response: vec![ResponseGuard {
-				rejection: RequestRejection::default(),
-				kind: ResponseGuardKind::Regex(RegexRules {
-					action: Action::Reject,
-					rules: vec![RegexRule::Regex {
-						pattern: regex::Regex::new("BLOCK_THIS").unwrap(),
-					}],
-				}),
-			}],
-		};
-
-		let proxy = crate::test_helpers::proxymock::setup_proxy_test("{}").unwrap();
-		let policy = PolicyClient::new(proxy.inputs());
-		let log = AsyncLog::default();
-
-		let (client_io, mut test_client) = tokio::io::duplex(65536);
-		let (mut test_server, server_io) = tokio::io::duplex(65536);
-
-		tokio::spawn(guarded_realtime_proxy(
-			client_io,
-			server_io,
-			guard,
-			policy,
-			log,
-			::http::HeaderMap::new(),
-		));
-
-		// Helpers to build raw WebSocket frames
-		fn text_frame_server(payload: &str) -> Vec<u8> {
-			let bytes = encode_ws_text_frame(payload.as_bytes());
-			bytes.to_vec()
-		}
-		fn text_frame_client_masked(payload: &str) -> Vec<u8> {
-			let bytes = encode_ws_text_frame_masked(payload.as_bytes(), [0, 0, 0, 0]);
-			bytes.to_vec()
-		}
-
-		// Build a delta event (1025 bytes) that contains BLOCK_THIS so the guard fires.
-		let blocked_text: String = "BLOCK_THIS".to_string() + &"X".repeat(1015);
-		let resp_a_delta = serde_json::json!({
-			"type": "response.output_text.delta",
-			"response_id": "resp_A",
-			"delta": blocked_text,
-		});
-
-		let resp_b_delta = serde_json::json!({
-			"type": "response.output_text.delta",
-			"response_id": "resp_B",
-			"delta": "clean content from B",
-		});
-
-		let resp_b_done = serde_json::json!({
-			"type": "response.output_text.done",
-			"response_id": "resp_B",
-		});
-
-		use tokio::io::AsyncWriteExt as _;
-		test_server
-			.write_all(&text_frame_server(&resp_a_delta.to_string()))
-			.await
-			.unwrap();
-		test_server
-			.write_all(&text_frame_server(&resp_b_delta.to_string()))
-			.await
-			.unwrap();
-		test_server
-			.write_all(&text_frame_server(&resp_b_done.to_string()))
-			.await
-			.unwrap();
-
-		// Give the proxy time to process and flush events to the client.
-		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-		// Read whatever arrived at the test client within a short deadline.
-		use tokio::io::AsyncReadExt as _;
-		let mut buf = vec![0u8; 65536];
-		let mut accum = WsFrameAccumulator::new();
-		let mut events: Vec<serde_json::Value> = Vec::new();
-		let deadline = std::time::Duration::from_millis(500);
-		loop {
-			match tokio::time::timeout(deadline, test_client.read(&mut buf)).await {
-				Ok(Ok(0)) | Err(_) => break,
-				Ok(Ok(n)) => {
-					accum.push(&buf[..n]);
-					for frame in accum.drain_frames() {
-						if let WsCompletedFrame::Text { payload, .. } = frame {
-							if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&payload) {
-								events.push(v);
-							}
-						}
-					}
-					if events.iter().any(|e| {
-						e.get("response_id").and_then(|v| v.as_str()) == Some("resp_B")
-					}) {
-						break;
-					}
-				},
-				Ok(Err(_)) => break,
-			}
-		}
-
-		// Fails without the fix: response_blocked=true drops all deltas regardless of response_id.
-		assert!(
-			events.iter().any(|e| {
-				e.get("type").and_then(|v| v.as_str()) == Some("response.output_text.delta")
-					&& e.get("response_id").and_then(|v| v.as_str()) == Some("resp_B")
-			}),
-			"resp_B delta must reach the client; received events: {events:?}"
-		);
-	}
 
 	#[test]
 	fn record_text_payload_disables_after_limit() {

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -234,9 +234,9 @@ fn guardrail_blocked_ws_event_bytes(body: Bytes) -> Bytes {
 ///
 /// The WebSocket spec requires client→server frames to be masked. We use a zero mask
 /// so the XOR is identity (payload bytes are unchanged) while the frame is formally masked.
-fn response_cancel_event_bytes(mask: [u8; 4]) -> Bytes {
-	let json = br#"{"type":"response.cancel"}"#;
-	encode_ws_text_frame_masked(json, mask)
+fn response_cancel_event_bytes(response_id: &str, mask: [u8; 4]) -> Bytes {
+	let json = format!(r#"{{"type":"response.cancel","response_id":"{response_id}"}}"#);
+	encode_ws_text_frame_masked(json.as_bytes(), mask)
 }
 
 // ---------------------------------------------------------------------------
@@ -349,6 +349,7 @@ pub async fn guarded_realtime_proxy<C, S>(
 	guard: PromptGuard,
 	policy_client: PolicyClient,
 	log: AsyncLog<LLMInfo>,
+	req_headers: ::http::HeaderMap,
 ) where
 	C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 	S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -366,6 +367,7 @@ pub async fn guarded_realtime_proxy<C, S>(
 	let guard_clone = guard.clone();
 	let policy_client_clone = policy_client.clone();
 	let log_clone = log.clone();
+	let req_headers_clone = req_headers;
 
 	let client_to_server = {
 		let server_tx = server_tx.clone();
@@ -429,11 +431,13 @@ pub async fn guarded_realtime_proxy<C, S>(
 			let mut accum = WsFrameAccumulator::new();
 			let mut read_buf = [0u8; 4096];
 			let mut evaluators =
-				guard_clone.begin_streaming_response_guard(&policy_client_clone, &::http::HeaderMap::new());
+				guard_clone.begin_streaming_response_guard(&policy_client_clone, &req_headers_clone);
 			let mut delta_hold: Vec<Bytes> = Vec::new();
 			let mut pending_text = String::new();
 			let mut overlap_tail = String::new();
-			let mut response_blocked = false;
+			// Keyed by response_id so that blocking one concurrent response does not
+			// suppress deltas from unrelated concurrent responses.
+			let mut blocked_responses: std::collections::HashSet<String> = std::collections::HashSet::new();
 
 			loop {
 				let n = match server_reader.read(&mut read_buf).await {
@@ -451,7 +455,7 @@ pub async fn guarded_realtime_proxy<C, S>(
 
 							match event {
 								Some(RealtimeServerEvent::ResponseOutputTextDelta(ref delta_event)) => {
-									if response_blocked {
+									if blocked_responses.contains(&delta_event.response_id) {
 										continue;
 									}
 									pending_text.push_str(&delta_event.delta);
@@ -464,12 +468,19 @@ pub async fn guarded_realtime_proxy<C, S>(
 
 										if let Some(blocked_body) = evaluate_window(&mut evaluators, &window).await {
 											delta_hold.clear();
-											response_blocked = true;
+											// Clear shared text-state so a blocked response's content
+											// does not bleed into subsequent concurrent responses.
+											overlap_tail.clear();
+											pending_text.clear();
+											blocked_responses.insert(delta_event.response_id.clone());
 											let _ = client_tx
 												.send(guardrail_blocked_ws_event_bytes(blocked_body))
 												.await;
 											let _ = server_tx
-												.send(response_cancel_event_bytes([0, 0, 0, 0]))
+												.send(response_cancel_event_bytes(
+													&delta_event.response_id,
+													[0, 0, 0, 0],
+												))
 												.await;
 										} else {
 											for f in delta_hold.drain(..) {
@@ -478,9 +489,9 @@ pub async fn guarded_realtime_proxy<C, S>(
 										}
 									}
 								},
-								Some(RealtimeServerEvent::ResponseOutputTextDone(_)) => {
-									if response_blocked {
-										response_blocked = false;
+								Some(RealtimeServerEvent::ResponseOutputTextDone(ref done_event)) => {
+									if blocked_responses.contains(&done_event.response_id) {
+										blocked_responses.remove(&done_event.response_id);
 										overlap_tail.clear();
 										pending_text.clear();
 										delta_hold.clear();
@@ -499,12 +510,15 @@ pub async fn guarded_realtime_proxy<C, S>(
 										delta_hold.clear();
 										// Prevent stale deltas from a race between the cancel
 										// reaching the server and buffered frames arriving here.
-										response_blocked = true;
+										blocked_responses.insert(done_event.response_id.clone());
 										let _ = client_tx
 											.send(guardrail_blocked_ws_event_bytes(blocked_body))
 											.await;
 										let _ = server_tx
-											.send(response_cancel_event_bytes([0, 0, 0, 0]))
+											.send(response_cancel_event_bytes(
+												&done_event.response_id,
+												[0, 0, 0, 0],
+											))
 											.await;
 									} else {
 										for f in delta_hold.drain(..) {
@@ -559,33 +573,183 @@ pub async fn guarded_realtime_proxy<C, S>(
 		}
 	};
 
-	let client_writer_task = async move {
+	// Spawn writer tasks as independent tokio tasks so they drain their channels
+	// concurrently with the reader loops. Without independent tasks, the writers
+	// would only run after a reader exits, which would drop buffered frames.
+	let client_writer_join = tokio::spawn(async move {
 		while let Some(bytes) = client_rx.recv().await {
 			if client_writer_io.write_all(&bytes).await.is_err() {
 				break;
 			}
 		}
-	};
+	});
 
-	let server_writer_task = async move {
+	let server_writer_join = tokio::spawn(async move {
 		while let Some(bytes) = server_rx.recv().await {
 			if server_writer_io.write_all(&bytes).await.is_err() {
 				break;
 			}
 		}
-	};
+	});
 
+	// Exit when either reader closes; then wait for writers to drain remaining frames.
 	tokio::select! {
 		_ = client_to_server => {},
 		_ = server_to_client => {},
-		_ = client_writer_task => {},
-		_ = server_writer_task => {},
 	}
+	let _ = tokio::join!(client_writer_join, server_writer_join);
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// Regression test for Bug 4: `response.cancel` must include `response_id` so the server
+	/// cancels the correct response in a multi-response session.
+	#[test]
+	fn response_cancel_includes_response_id() {
+		let bytes = response_cancel_event_bytes("resp_X", [0, 0, 0, 0]);
+		let mut accum = WsFrameAccumulator::new();
+		accum.push(&bytes);
+		let frames = accum.drain_frames();
+		let WsCompletedFrame::Text { payload, .. } = &frames[0] else {
+			panic!("expected text frame");
+		};
+		// Unmask: zero mask is identity.
+		let json: serde_json::Value = serde_json::from_slice(payload).unwrap();
+		assert_eq!(
+			json.get("response_id").and_then(|v| v.as_str()),
+			Some("resp_X"),
+			"response.cancel must carry response_id; got: {json}"
+		);
+	}
+
+	/// Regression test for Bugs 1, 2, 3: blocking resp_A must not suppress resp_B deltas.
+	///
+	/// Specifically exercises:
+	/// - Bug 1: `response_blocked` bool replaced with `HashSet<String>` keyed on response_id
+	/// - Bug 2: `tokio::select!` writer drain replaced with `tokio::join!` after readers exit
+	/// - Bug 3: `begin_streaming_response_guard` receives `req_headers` not `HeaderMap::new()`
+	#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+	async fn blocked_response_does_not_suppress_concurrent_response() {
+		use crate::llm::policy::{
+			Action, PromptGuard, RegexRule, RegexRules, RequestRejection, ResponseGuard, ResponseGuardKind,
+		};
+		use crate::proxy::httpproxy::PolicyClient;
+		use crate::telemetry::log::AsyncLog;
+
+		let guard = PromptGuard {
+			request: vec![],
+			response: vec![ResponseGuard {
+				rejection: RequestRejection::default(),
+				kind: ResponseGuardKind::Regex(RegexRules {
+					action: Action::Reject,
+					rules: vec![RegexRule::Regex {
+						pattern: regex::Regex::new("BLOCK_THIS").unwrap(),
+					}],
+				}),
+			}],
+		};
+
+		let proxy = crate::test_helpers::proxymock::setup_proxy_test("{}").unwrap();
+		let policy = PolicyClient::new(proxy.inputs());
+		let log = AsyncLog::default();
+
+		let (client_io, mut test_client) = tokio::io::duplex(65536);
+		let (mut test_server, server_io) = tokio::io::duplex(65536);
+
+		tokio::spawn(guarded_realtime_proxy(
+			client_io,
+			server_io,
+			guard,
+			policy,
+			log,
+			::http::HeaderMap::new(),
+		));
+
+		// Helpers to build raw WebSocket frames
+		fn text_frame_server(payload: &str) -> Vec<u8> {
+			let bytes = encode_ws_text_frame(payload.as_bytes());
+			bytes.to_vec()
+		}
+		fn text_frame_client_masked(payload: &str) -> Vec<u8> {
+			let bytes = encode_ws_text_frame_masked(payload.as_bytes(), [0, 0, 0, 0]);
+			bytes.to_vec()
+		}
+
+		// Build a delta event (1025 bytes) that contains BLOCK_THIS so the guard fires.
+		let blocked_text: String = "BLOCK_THIS".to_string() + &"X".repeat(1015);
+		let resp_a_delta = serde_json::json!({
+			"type": "response.output_text.delta",
+			"response_id": "resp_A",
+			"delta": blocked_text,
+		});
+
+		let resp_b_delta = serde_json::json!({
+			"type": "response.output_text.delta",
+			"response_id": "resp_B",
+			"delta": "clean content from B",
+		});
+
+		let resp_b_done = serde_json::json!({
+			"type": "response.output_text.done",
+			"response_id": "resp_B",
+		});
+
+		use tokio::io::AsyncWriteExt as _;
+		test_server
+			.write_all(&text_frame_server(&resp_a_delta.to_string()))
+			.await
+			.unwrap();
+		test_server
+			.write_all(&text_frame_server(&resp_b_delta.to_string()))
+			.await
+			.unwrap();
+		test_server
+			.write_all(&text_frame_server(&resp_b_done.to_string()))
+			.await
+			.unwrap();
+
+		// Give the proxy time to process and flush events to the client.
+		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+		// Read whatever arrived at the test client within a short deadline.
+		use tokio::io::AsyncReadExt as _;
+		let mut buf = vec![0u8; 65536];
+		let mut accum = WsFrameAccumulator::new();
+		let mut events: Vec<serde_json::Value> = Vec::new();
+		let deadline = std::time::Duration::from_millis(500);
+		loop {
+			match tokio::time::timeout(deadline, test_client.read(&mut buf)).await {
+				Ok(Ok(0)) | Err(_) => break,
+				Ok(Ok(n)) => {
+					accum.push(&buf[..n]);
+					for frame in accum.drain_frames() {
+						if let WsCompletedFrame::Text { payload, .. } = frame {
+							if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&payload) {
+								events.push(v);
+							}
+						}
+					}
+					if events.iter().any(|e| {
+						e.get("response_id").and_then(|v| v.as_str()) == Some("resp_B")
+					}) {
+						break;
+					}
+				},
+				Ok(Err(_)) => break,
+			}
+		}
+
+		// Fails without the fix: response_blocked=true drops all deltas regardless of response_id.
+		assert!(
+			events.iter().any(|e| {
+				e.get("type").and_then(|v| v.as_str()) == Some("response.output_text.delta")
+					&& e.get("response_id").and_then(|v| v.as_str()) == Some("resp_B")
+			}),
+			"resp_B delta must reach the client; received events: {events:?}"
+		);
+	}
 
 	#[test]
 	fn record_text_payload_disables_after_limit() {

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -238,7 +238,7 @@ fn response_cancel_event_bytes(mask: [u8; 4]) -> Bytes {
 	// NOTE: response.cancel is sent without a response_id; the server cancels its most-recent
 	// active response. Correctly targeting a specific response in the Realtime API's out-of-band
 	// (concurrent) response pattern requires a response_id here and per-response blocked tracking
-	// — that is a known gap tracked in a follow-up issue.
+	// — see https://github.com/agentgateway/agentgateway/issues/2213.
 	let json = r#"{"type":"response.cancel"}"#;
 	encode_ws_text_frame_masked(json.as_bytes(), mask)
 }

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -603,8 +603,8 @@ pub async fn guarded_realtime_proxy<C, S>(
 mod tests {
 	use super::*;
 
-	/// Regression test for Bug 4: `response.cancel` must include `response_id` so the server
-	/// cancels the correct response in a multi-response session.
+	/// `response.cancel` must include `response_id` so the server cancels the correct response
+	/// in a multi-response session.
 	#[test]
 	fn response_cancel_includes_response_id() {
 		let bytes = response_cancel_event_bytes("resp_X", [0, 0, 0, 0]);
@@ -623,12 +623,9 @@ mod tests {
 		);
 	}
 
-	/// Regression test for Bugs 1, 2, 3: blocking resp_A must not suppress resp_B deltas.
-	///
-	/// Specifically exercises:
-	/// - Bug 1: `response_blocked` bool replaced with `HashSet<String>` keyed on response_id
-	/// - Bug 2: `tokio::select!` writer drain replaced with `tokio::join!` after readers exit
-	/// - Bug 3: `begin_streaming_response_guard` receives `req_headers` not `HeaderMap::new()`
+	/// Blocking one response must not suppress deltas from a concurrent response on the same
+	/// connection. Exercises per-response-id blocked tracking, writer-task drain ordering,
+	/// and correct header forwarding to the response guard.
 	#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 	async fn blocked_response_does_not_suppress_concurrent_response() {
 		use crate::llm::policy::{

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -367,7 +367,6 @@ pub async fn guarded_realtime_proxy<C, S>(
 	let guard_clone = guard.clone();
 	let policy_client_clone = policy_client.clone();
 	let log_clone = log.clone();
-	let req_headers_clone = req_headers;
 
 	let client_to_server = {
 		let server_tx = server_tx.clone();
@@ -431,7 +430,7 @@ pub async fn guarded_realtime_proxy<C, S>(
 			let mut accum = WsFrameAccumulator::new();
 			let mut read_buf = [0u8; 4096];
 			let mut evaluators =
-				guard_clone.begin_streaming_response_guard(&policy_client_clone, &req_headers_clone);
+				guard_clone.begin_streaming_response_guard(&policy_client_clone, &req_headers);
 			let mut delta_hold: Vec<Bytes> = Vec::new();
 			let mut pending_text = String::new();
 			let mut overlap_tail = String::new();

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1258,6 +1258,7 @@ impl HTTPProxy {
 				.extensions_mut()
 				.insert(BackendRequestTimeout(backend_timeout));
 		}
+		let upgrade_req_headers = req.headers().clone();
 		let mut req_opt = Some(req);
 		let timeout = response_policies
 			.timeout
@@ -1317,6 +1318,7 @@ impl HTTPProxy {
 				resp.extensions_mut().insert(RealtimeGuardContext {
 					prompt_guard,
 					policy_client: self.policy_client(),
+					req_headers: upgrade_req_headers,
 				});
 			}
 		}
@@ -1395,6 +1397,7 @@ async fn handle_upgrade(
 					guard_context.prompt_guard,
 					guard_context.policy_client,
 					llm,
+					guard_context.req_headers,
 				)
 				.await;
 				return;
@@ -3340,6 +3343,7 @@ struct ConnectTunnel {
 struct RealtimeGuardContext {
 	prompt_guard: crate::llm::policy::PromptGuard,
 	policy_client: PolicyClient,
+	req_headers: ::http::HeaderMap,
 }
 
 fn hop_by_hop_headers(req: &mut Request) -> Option<RequestUpgrade> {


### PR DESCRIPTION
## Summary

This PR fixes three bugs in the WebSocket realtime guardrail path. Rebased onto `keithmattix:streaming-guardrails` tip (`b00c0107`). Out-of-band (concurrent) response support is tracked separately in agentgateway/agentgateway#2213.

### Writer tasks dropped before flushing

Writer tasks were included as arms of `tokio::select!`. When either reader exited, the select exited immediately, dropping queued frames in the mpsc channels. Spawning the writers as independent `tokio::spawn` tasks lets them drain concurrently with readers; the readers' select is followed by `tokio::join!` on the writer handles to wait for remaining frames.

### Empty `HeaderMap` passed to guardrail

`begin_streaming_response_guard` received `HeaderMap::new()` instead of the actual request headers. This is a silent failure for any webhook response guard configured with `forwardHeaderMatches`: the webhook would be called without the matched headers (e.g. an auth token or tenant ID), producing auth failures or incorrect evaluations at the external guardrail service.

Fixed by adding `req_headers` to `RealtimeGuardContext` and threading it through `handle_upgrade` to `guarded_realtime_proxy`. The headers are used by `get_webhook_forward_headers` when building the outbound webhook request; regex and Bedrock guards ignore them.

### Double metric emission on FailOpen

`apply_webhook` recorded `GuardrailAction::FailOpen` internally then returned `GuardrailOutcome::None`, causing callers to also record `GuardrailAction::Allow`. Added a `FailOpen` variant to `GuardrailOutcome` so recording happens exactly once at the call site. Also changed `apply_webhook_response` to return `GuardrailOutcome` directly, fixing the same double-recording for the response webhook path (Mask/Reject/Pass were also double-recorded through `apply_single_response_guard`).

## Tests

- `llm::policy::tests::webhook_fail_open_emits_single_metric` — double metric emission on FailOpen

This test fails against `keithmattix:streaming-guardrails` without this patch. Full suite: 1304 tests, 0 failures.

## Test plan

- [ ] `cargo test -p agentgateway --lib -- webhook_fail_open_emits_single_metric`
- [ ] `cargo test -p agentgateway`
